### PR TITLE
Add attributes for CSS selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "author": "Sam Gwilym",
   "module": "dist/react-earthstar.esm.js",
   "devDependencies": {
+    "@types/react-dom": "^16.9.8",
     "eslint-plugin-react-hooks": "^4.1.2",
     "husky": "^4.3.0",
     "parcel": "^1.12.4",

--- a/src/components/AddWorkspaceForm.tsx
+++ b/src/components/AddWorkspaceForm.tsx
@@ -11,22 +11,37 @@ export default function AddWorkspaceForm() {
   const [, setPubs] = useWorkspacePubs(workspaceAddress);
 
   return (
-    <div>
-      <label htmlFor={'new-workspace-address'}>{'Workspace address'}</label>
+    <>
+      <label
+        data-react-earthstar-add-workspace-address-label
+        htmlFor={'new-workspace-address'}
+      >
+        {'Workspace address'}
+      </label>
       <input
+        data-react-earthstar-add-workspace-address-input
         name={'new-workspace-address'}
+        placeholder={'+workspace.a123'}
         value={workspaceAddress}
         onChange={e => setWorkspaceAddress(e.target.value)}
       />
 
-      <label htmlFor={'initial-pub-address'}>{'Pub address'}</label>
+      <label
+        data-react-earthstar-add-workspace-pub-label
+        htmlFor={'initial-pub-address'}
+      >
+        {'Pub address'}
+      </label>
       <input
+        data-react-earthstar-add-workspace-pub-input
         name={'initial-pub-address'}
+        placeholder={'https://my.pub/'}
         value={initialPub}
         type="url"
         onChange={e => setInitialPub(e.target.value)}
       />
       <button
+        data-react-earthstar-add-workspace-button
         onClick={() => {
           const result = add(workspaceAddress);
 
@@ -39,6 +54,6 @@ export default function AddWorkspaceForm() {
       >
         {'Add workspace'}
       </button>
-    </div>
+    </>
   );
 }

--- a/src/components/AuthorKeypairForm.tsx
+++ b/src/components/AuthorKeypairForm.tsx
@@ -9,17 +9,23 @@ export default function AuthorKeypairForm() {
   const [, setCurrentAuthor] = useCurrentAuthor();
 
   return (
-    <div>
-      <label htmlFor="author-address">{'Address'}</label>
+    <>
+      <label react-earthstar-author-form-address-label htmlFor="author-address">
+        {'Address'}
+      </label>
       <input
+        react-earthstar-author-form-address-input
         name="author-address"
         type="text"
         value={address}
         onChange={e => setAddress(e.target.value)}
       />
 
-      <label htmlFor={'author-secret'}>{'Secret'}</label>
+      <label react-earthstar-author-form-secret-label htmlFor={'author-secret'}>
+        {'Secret'}
+      </label>
       <input
+        react-earthstar-author-form-secret-input
         name={'author-secret'}
         type="password"
         value={secret}
@@ -27,6 +33,7 @@ export default function AuthorKeypairForm() {
       />
 
       <button
+        react-earthstar-author-form-button
         onClick={() => {
           const keypair = { address, secret };
 
@@ -42,6 +49,6 @@ export default function AuthorKeypairForm() {
       >
         {'Sign in'}
       </button>
-    </div>
+    </>
   );
 }

--- a/src/components/AuthorKeypairUpload.tsx
+++ b/src/components/AuthorKeypairUpload.tsx
@@ -2,11 +2,15 @@ import React from 'react';
 import { checkAuthorKeypairIsValid, isErr } from 'earthstar';
 import { useCurrentAuthor } from '../hooks';
 
-export default function AuthorKeypairUpload() {
+type AuthorKeypairUploadProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+export default function AuthorKeypairUpload(props: AuthorKeypairUploadProps) {
   const [, setCurrentAuthor] = useCurrentAuthor();
 
   return (
     <input
+      {...props}
+      data-react-earthstar-keypair-upload-input
       type="file"
       accept={'application/json,.keypair.json'}
       onChange={e => {

--- a/src/components/AuthorLabel.tsx
+++ b/src/components/AuthorLabel.tsx
@@ -1,6 +1,15 @@
 import React from 'react';
 import { getAuthorShortName } from '../util';
 
-export default function AuthorLabel({ address }: { address: string }) {
-  return <span title={address}>{`@${getAuthorShortName(address)}`}</span>;
+export default function AuthorLabel({
+  address,
+  ...props
+}: { address: string } & React.HTMLAttributes<HTMLSpanElement>) {
+  return (
+    <span
+      {...props}
+      data-react-earthstar-author-label
+      title={address}
+    >{`@${getAuthorShortName(address)}`}</span>
+  );
 }

--- a/src/components/CurrentAuthor.tsx
+++ b/src/components/CurrentAuthor.tsx
@@ -6,13 +6,9 @@ import { useCurrentAuthor } from '../hooks';
 export default function CurrentAuthor() {
   const [currentAuthor] = useCurrentAuthor();
 
-  return (
-    <div>
-      {currentAuthor ? (
-        <AuthorLabel address={currentAuthor.address} />
-      ) : (
-        'Not signed in'
-      )}
-    </div>
+  return currentAuthor ? (
+    <AuthorLabel address={currentAuthor.address} />
+  ) : (
+    'Not signed in'
   );
 }

--- a/src/components/DisplayNameForm.tsx
+++ b/src/components/DisplayNameForm.tsx
@@ -21,8 +21,12 @@ export default function DisplayNameForm({ workspace }: { workspace: string }) {
 
   return (
     <>
-      <label htmlFor={`author-display-name-${workspace}`}></label>
+      <label
+        react-earthstar-display-name-label
+        htmlFor={`author-display-name-${workspace}`}
+      ></label>
       <input
+        react-earthstar-display-name-input
         value={newDisplayName}
         onChange={e => setNewDisplayName(e.target.value)}
         placeholder={
@@ -31,6 +35,7 @@ export default function DisplayNameForm({ workspace }: { workspace: string }) {
         }
       />
       <button
+        react-earthstar-display-name-button
         onClick={() => {
           setNewDisplayName('');
           setDisplayNameDoc(newDisplayName);

--- a/src/components/DownloadKeypairButton.tsx
+++ b/src/components/DownloadKeypairButton.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { useCurrentAuthor } from '../hooks';
 
-export default function DownloadKeypairButton() {
+export default function DownloadKeypairButton(
+  props: React.HTMLAttributes<HTMLButtonElement>
+) {
   const [currentAuthor] = useCurrentAuthor();
 
   const download = React.useCallback(() => {
@@ -25,7 +27,12 @@ export default function DownloadKeypairButton() {
   }, [currentAuthor]);
 
   return (
-    <button onClick={download} disabled={currentAuthor === null}>
+    <button
+      {...props}
+      data-react-earthstar-download-keypair-button
+      onClick={download}
+      disabled={currentAuthor === null}
+    >
       {'Download keypair.json'}
     </button>
   );

--- a/src/components/NewKeypairForm.tsx
+++ b/src/components/NewKeypairForm.tsx
@@ -29,15 +29,23 @@ export default function NewKeypairForm() {
   }, [setCurrentAuthor, shortName, currentAuthor]);
 
   return (
-    <div>
-      <label htmlFor={'short-name-input'}>Short name</label>
+    <>
+      <label
+        react-earthstar-keypair-form-shortname-label
+        htmlFor={'short-name-input'}
+      >
+        Short name
+      </label>
       <input
+        react-earthstar-keypair-form-shortname-input
         name={'short-name-input'}
         placeholder={'4-letter nickname'}
         value={shortName}
         onChange={e => setShortName(e.target.value)}
       />
-      <button onClick={onCreate}>{'Create'}</button>
-    </div>
+      <button react-earthstar-keypair-form-button onClick={onCreate}>
+        {'Create'}
+      </button>
+    </>
   );
 }

--- a/src/components/PubEditor.tsx
+++ b/src/components/PubEditor.tsx
@@ -23,12 +23,15 @@ export default function PubEditor({ workspace }: { workspace: string }) {
   return (
     <>
       {pubs.length > 0 ? (
-        <ul>
+        <ul data-react-earthstar-pubeditor-list>
           {pubs.map(pubUrl => {
             return (
-              <li key={`${pubUrl}`}>
+              <li data-react-earthstar-pubeditor-list-item key={`${pubUrl}`}>
                 {pubUrl}
-                <button onClick={() => removePub(pubUrl)}>
+                <button
+                  data-react-earthstar-pubeditor-list-item-delete-button
+                  onClick={() => removePub(pubUrl)}
+                >
                   {'Remove pub'}
                 </button>
               </li>
@@ -36,8 +39,11 @@ export default function PubEditor({ workspace }: { workspace: string }) {
           })}
         </ul>
       ) : null}
-      <label htmlFor={'pub-to-add'}>{'Pub URL'}</label>
+      <label data-react-earthstar-pubeditor-newpub-label htmlFor={'pub-to-add'}>
+        {'Pub URL'}
+      </label>
       <input
+        data-react-earthstar-pubeditor-newpub-input
         type="url"
         name={'pub-to-add'}
         value={pubToAdd}
@@ -45,6 +51,7 @@ export default function PubEditor({ workspace }: { workspace: string }) {
         placeholder={'https://my.pub/'}
       />
       <button
+        data-react-earthstar-pubeditor-add-button
         onClick={() => {
           if (pubToAdd.length > 0) {
             addPub(pubToAdd);

--- a/src/components/SignOutButton.tsx
+++ b/src/components/SignOutButton.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
 import { useCurrentAuthor } from '../hooks';
 
-export default function SignOutButton() {
+export default function SignOutButton(
+  props: React.HTMLAttributes<HTMLButtonElement>
+) {
   const [currentAuthor, setCurrentAuthor] = useCurrentAuthor();
 
   return (
     <button
+      {...props}
+      react-earthstar-sign-out-button
       onClick={() => setCurrentAuthor(null)}
       disabled={currentAuthor === null}
     >

--- a/src/components/TODO.md
+++ b/src/components/TODO.md
@@ -1,12 +1,9 @@
 # Components to make
 
 - RemoveWorkspaceButton
+- Rework AddWorkspaceForm to use Earthstar URL
 
 # Things to do
-
-- Basics
-
-  - Add placeholder text to AddWorkspaceForm
 
 - Styling
   - Add `className` props to components

--- a/src/components/WorkspaceLabel.tsx
+++ b/src/components/WorkspaceLabel.tsx
@@ -23,6 +23,15 @@ function getWorkspaceName(address: string) {
   return address;
 }
 
-export default function WorkspaceLabel({ address }: { address: string }) {
-  return <span title={address}>{`+${getWorkspaceName(address)}`}</span>;
+export default function WorkspaceLabel({
+  address,
+  ...props
+}: { address: string } & React.HTMLAttributes<HTMLSpanElement>) {
+  return (
+    <span
+      {...props}
+      data-react-earthstar-workspace-label
+      title={address}
+    >{`+${getWorkspaceName(address)}`}</span>
+  );
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src", "types"],
+  "include": ["src", "types", "examples"],
   "compilerOptions": {
     "module": "esnext",
     "lib": ["dom", "esnext"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1289,6 +1289,13 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.4.tgz#15925414e0ad2cd765bfef58842f7e26a7accb24"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
 
+"@types/react-dom@^16.9.8":
+  version "16.9.8"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.8.tgz#fe4c1e11dfc67155733dfa6aa65108b4971cb423"
+  integrity sha512-ykkPQ+5nFknnlU6lDd947WbQ6TE3NNzbQAkInC2EKY1qeYdTKp7onFusmYZb+ityzx2YviqT6BXSu+LyWWJwcA==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-test-renderer@*":
   version "16.9.3"
   resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.9.3.tgz#96bab1860904366f4e848b739ba0e2f67bcae87e"


### PR DESCRIPTION
If you use components from react-earthstar, you should have three choices when it comes to styling:

1. You can use the provided styles
2. You can use the provided styles and add to them (e.g. colours, typefaces)
3. You can *not* use the provided styles and handle styling by yourself completely.

You should be able to style them however you want: normal stylesheets, styled-components, emotion.

I did a bit of searching into prior art for this and the approach I like most was that of https://reach.tech, a collection of accessibility focused reusable components.

Their approach:

- For components that represent a single semantic block (like a single checkbox, label), allow props like `className` and `style` to be passed to them and onto the root elements.
- For all elements, add `data-` attributes with very specific names which provide hooks for selecting those elements. I believe this is to avoid possible collisions with user style names, and also to better associate the semantic meaning of the targeted element without depending on things like `input`, `button` etc. You can see how this works out from Reach's [styling guide].

We'll be able to see how well this approach works while building the EarthBar component, which will style all the individual components and put them in a standard layout.