### PR TITLE
adjust example page styles again

### DIFF
--- a/examples/components/index.tsx
+++ b/examples/components/index.tsx
@@ -37,7 +37,7 @@ function Example({
         style={{
           margin: '1em 0 0.5rem 1rem',
           padding: 0,
-          color: '#3a5',
+          color: '#097',
           fontSize: '1.5em',
         }}
       >
@@ -47,7 +47,7 @@ function Example({
         style={{
           margin: '0 0 0.5rem 1rem',
           fontStyle: 'italic',
-          color: '#084',
+          color: '#097',
         }}
       >
         {notes}
@@ -55,10 +55,10 @@ function Example({
       <div
         style={{
           margin: '0 1rem 0 2rem',
-          border: '2px dotted #084',
+          border: '2px dotted #888',
           padding: '1em',
           boxShadow: '5px 5px 5px 0px rgba(0,0,0,0.3)',
-          background: 'rgb(208, 232, 220)',
+          background: '#eee',
         }}
       >
         {children}


### PR DESCRIPTION
> I found that with the green outline and grey background, some of the examples read a little bit like text inputs. Tweaks the style a little so it reads a little less like one (?)
> ![](https://user-images.githubusercontent.com/579491/94992201-9fd29000-0588-11eb-847d-c1e071964a35.png)

First of all please feel free to ignore this PR, style is very subjective!

To me that looks even more like a text input. :)

I want to feel a really clear separation between the inside and outside of these components, like they're hanging on the wall in fancy little frames.  How's this?  I made the background non-white because it helps the `<input>`s stand out more, and used dotted lines and shadows to avoid looking like a text input.

![Screen Shot 2020-10-03 at 2 39 27 PM](https://user-images.githubusercontent.com/32660718/95002205-45d0cb00-0586-11eb-9357-8deca7b1e4eb.png)

![Screen Shot 2020-10-03 at 2 41 03 PM](https://user-images.githubusercontent.com/32660718/95002231-7dd80e00-0586-11eb-8384-60942d71d463.png)

