### PR TITLE
Add RemoveWorkspaceButton

### DIFF
--- a/examples/components/index.tsx
+++ b/examples/components/index.tsx
@@ -12,6 +12,7 @@ import {
   EarthstarPeer,
   NewKeypairForm,
   PubEditor,
+  RemoveWorkspaceButton,
   SignOutButton,
   WorkspaceLabel,
   WorkspaceList,
@@ -81,14 +82,25 @@ function Examples() {
         ]}
       >
         <hr />
-        <h2>Adding and editing workspaces</h2>
+        <h2>Adding, removing and editing workspaces</h2>
         <Example
           title={'AddWorkspaceForm'}
           notes="Add a new workspace to the list of possible workspaces"
         >
           <AddWorkspaceForm />
         </Example>
-        <Example title={'PubEditor'} notes="Add or remove pubs from a given workspace.">
+        <Example
+          title={'RemoveWorkspaceButton'}
+          notes={'Remove a workspace from the list of known workspaces'}
+        >
+          <RemoveWorkspaceButton workspaceAddress={EXAMPLE_WORKSPACE_ADDR3}>
+            {`Remove ${EXAMPLE_WORKSPACE_ADDR3}`}
+          </RemoveWorkspaceButton>
+        </Example>
+        <Example
+          title={'PubEditor'}
+          notes="Add or remove pubs from a given workspace."
+        >
           <PubEditor workspace={EXAMPLE_WORKSPACE_ADDR1} />
         </Example>
         <Example title={'WorkspaceList'} notes="List the known workspaces">
@@ -130,7 +142,10 @@ function Examples() {
         >
           <CurrentAuthor />
         </Example>
-        <Example title={'DisplayNameForm'} notes="Change the display name of the currently signed in author, in a given workspace">
+        <Example
+          title={'DisplayNameForm'}
+          notes="Change the display name of the currently signed in author, in a given workspace"
+        >
           <DisplayNameForm workspace={EXAMPLE_WORKSPACE_ADDR1} />
         </Example>
         <hr />
@@ -145,7 +160,10 @@ function Examples() {
             }
           />
         </Example>
-        <Example title={'WorkspaceLabel'} notes="Abbreviate a workspace address for easy viewing">
+        <Example
+          title={'WorkspaceLabel'}
+          notes="Abbreviate a workspace address for easy viewing"
+        >
           <WorkspaceLabel address={EXAMPLE_WORKSPACE_ADDR1} />
         </Example>
       </EarthstarPeer>

--- a/src/components/CurrentAuthor.tsx
+++ b/src/components/CurrentAuthor.tsx
@@ -9,6 +9,6 @@ export default function CurrentAuthor() {
   return currentAuthor ? (
     <AuthorLabel address={currentAuthor.address} />
   ) : (
-    'Not signed in'
+    <>'Not signed in'</>
   );
 }

--- a/src/components/RemoveWorkspaceButton.tsx
+++ b/src/components/RemoveWorkspaceButton.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { useRemoveWorkspace } from '../hooks';
+
+export default function RemoveWorkspaceButton({
+  workspaceAddress,
+  children,
+  ...props
+}: { workspaceAddress: string } & React.HTMLAttributes<HTMLButtonElement>) {
+  const remove = useRemoveWorkspace();
+
+  return (
+    <button
+      data-react-earthstar-remove-workspace-button
+      {...props}
+      onClick={() => {
+        const isSure = window.confirm(
+          `Are you sure you want to remove ${workspaceAddress} from your workspaces?`
+        );
+
+        if (isSure) {
+          remove(workspaceAddress);
+        }
+      }}
+    >
+      {children || `Remove ${workspaceAddress}`}
+    </button>
+  );
+}

--- a/src/components/TODO.md
+++ b/src/components/TODO.md
@@ -1,12 +1,10 @@
 # Components to make
 
-- RemoveWorkspaceButton
-- Rework AddWorkspaceForm to use Earthstar URL
+- Rework AddWorkspaceForm to use Earthstar URLs
 
 # Things to do
 
 - Styling
-  - Add `className` props to components
   - Add some kind of styling guide for each component...
   - Add default styles which can be optionally used
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,7 @@ export { default as DisplayNameForm } from './components/DisplayNameForm';
 export { default as DownloadKeypairButton } from './components/DownloadKeypairButton';
 export { default as NewKeypairForm } from './components/NewKeypairForm';
 export { default as PubEditor } from './components/PubEditor';
+export { default as RemoveWorkspaceButton } from './components/RemoveWorkspaceButton';
 export { default as SignOutButton } from './components/SignOutButton';
 export { default as WorkspaceLabel } from './components/WorkspaceLabel';
 export { default as WorkspaceList } from './components/WorkspaceList';


### PR DESCRIPTION
Adds a `RemoveWorkspaceButton`, which asks to confirm your decision when clicked. A little different from other buttons in that you can pass it children so you can set its label yourself.

<img width="745" alt="Screenshot 2020-10-04 at 15 39 06" src="https://user-images.githubusercontent.com/579491/95017141-cf040280-0657-11eb-8ee6-61f42a044c3b.png">
