### PR TITLE
package.json: use regular react version instead of linking to earthstar-status

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@testing-library/react-hooks": "^3.4.1",
     "earthstar": "^5.2.6",
-    "react": "link:../earthstar-status/node_modules/react",
+    "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-test-renderer": "^16.13.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7030,9 +7030,14 @@ react-test-renderer@^16.13.1:
     react-is "^16.8.6"
     scheduler "^0.19.1"
 
-"react@link:../earthstar-status/node_modules/react":
-  version "0.0.0"
-  uid ""
+react@^16.13.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
+  integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
 
 read-pkg-up@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Package.json had a link to a local directory for `react`.  Amazingly, the build still worked but it was preventing `lint` from running.