### PR TITLE
Make earthstar a peer dependency, remove storage on workspace removal

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "earthbar-example": "parcel examples/earthbar/index.html --port 2345"
   },
   "peerDependencies": {
+    "earthstar": "^5.7.4",
     "react": "~16.13.1"
   },
   "husky": {
@@ -40,6 +41,7 @@
     "@types/jest": "^26.0.14",
     "@types/react-dom": "^16.9.8",
     "babel-jest": "^26.5.2",
+    "earthstar": "^5.7.4",
     "eslint-plugin-react-hooks": "^4.1.2",
     "husky": "^4.3.0",
     "parcel": "^1.12.4",
@@ -60,7 +62,7 @@
     "@reach/descendants": "0.11.2",
     "@reach/utils": "^0.11.2",
     "@testing-library/react-hooks": "^3.4.2",
-    "earthstar": "^5.4.0",
+    
     "use-deep-compare-effect": "^1.4.0"
   }
 }

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -119,7 +119,7 @@ export function useAddWorkspace() {
 }
 
 export function useRemoveWorkspace() {
-  const [, setStorages] = useStorages();
+  const [storages, setStorages] = useStorages();
   const [currentWorkspace, setCurrentWorkspace] = useCurrentWorkspace();
 
   return React.useCallback(
@@ -135,8 +135,10 @@ export function useRemoveWorkspace() {
 
         return prevCopy;
       });
+
+      storages[address]?.deleteAndClose();
     },
-    [setStorages, currentWorkspace, setCurrentWorkspace]
+    [setStorages, currentWorkspace, setCurrentWorkspace, storages]
   );
 }
 

--- a/test/hooks.test.tsx
+++ b/test/hooks.test.tsx
@@ -101,17 +101,24 @@ test('useAddWorkspace ', () => {
 
 test('useRemoveWorkspace', () => {
   const useTest = () => {
+    const [storages] = useStorages();
     const remove = useRemoveWorkspace();
     const workspaces = useWorkspaces();
 
-    return { remove, workspaces };
+    return { remove, workspaces, storages };
   };
 
   const { result } = renderHook(() => useTest(), { wrapper });
 
+  const storage = result.current.storages[WORKSPACE_ADDR_C];
+
+  expect(storage.isClosed()).toBeFalsy();
+
   act(() => {
     result.current.remove(WORKSPACE_ADDR_C);
   });
+
+  expect(storage.isClosed()).toBeTruthy();
 
   expect(result.current.workspaces).toEqual([
     WORKSPACE_ADDR_A,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3349,10 +3349,10 @@ duplexer2@~0.1.4:
   dependencies:
     readable-stream "^2.0.2"
 
-earthstar@^5.4.0:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/earthstar/-/earthstar-5.4.0.tgz#6c72f0da090ffaf433203ff497edc2e4788a1518"
-  integrity sha512-+zNQiuU9ye/LuP3ejK78loMxwXza1PLkJReQ7yp1EaDuuSIbNLzi4oBajxCuCvWSnO0LfcmDOD2BiBLoIKMv+A==
+earthstar@^5.7.4:
+  version "5.7.4"
+  resolved "https://registry.yarnpkg.com/earthstar/-/earthstar-5.7.4.tgz#c986ef545774fd5a6f27a98b8aaaf0de4fa3f42c"
+  integrity sha512-bJvn4Z3RwV0MAPAq4OCpaJrFlpmvL8XctV56kR/j0nhlvt7gPvULJluVW2IBpW/XEdgD3qY/jT7Wh+lonqSaXw==
   dependencies:
     "@types/isomorphic-fetch" "0.0.35"
     bencode "^2.0.1"


### PR DESCRIPTION
- Makes it so that earthstar is a peer dependency of react-earthstar (as a lot of the time you will be installing it side-by-side). 
- Makes it so that removing a workspace triggers the new `deleteAndClose` method

Closes #19 