### PR TITLE
InvitationRedemptionForm + InvitationCreationForm + pop them into Earthbar

### DIFF
--- a/examples/components/index.tsx
+++ b/examples/components/index.tsx
@@ -11,6 +11,7 @@ import {
   CurrentWorkspaceSelect,
   DisplayNameForm,
   DownloadKeypairButton,
+  InvitationCreatorForm,
   InvitationRedemptionForm,
   NewKeypairForm,
   PubEditor,
@@ -84,6 +85,11 @@ function Examples() {
           new StorageMemory([ValidatorEs4], EXAMPLE_WORKSPACE_ADDR2),
           new StorageMemory([ValidatorEs4], EXAMPLE_WORKSPACE_ADDR3),
         ]}
+        initPubs={{
+          [EXAMPLE_WORKSPACE_ADDR1]: ['https://a.pub/', 'https://z.pub/'],
+          [EXAMPLE_WORKSPACE_ADDR2]: ['https://b.pub/'],
+          [EXAMPLE_WORKSPACE_ADDR3]: ['https://c.pub/'],
+        }}
       >
         <hr />
         <h2>Adding, removing and editing workspaces</h2>
@@ -104,6 +110,12 @@ function Examples() {
           notes={'Add a workspace using an Earthstar invitation code'}
         >
           <InvitationRedemptionForm />
+        </Example>
+        <Example
+          title={'InvitationCreatorForm'}
+          notes={'Create Earthstar invitation code from a workspace'}
+        >
+          <InvitationCreatorForm workspace={EXAMPLE_WORKSPACE_ADDR1} />
         </Example>
         <Example
           title={'RemoveWorkspaceButton'}

--- a/examples/components/index.tsx
+++ b/examples/components/index.tsx
@@ -11,6 +11,7 @@ import {
   CurrentWorkspaceSelect,
   DisplayNameForm,
   DownloadKeypairButton,
+  InvitationRedemptionForm,
   NewKeypairForm,
   PubEditor,
   RemoveWorkspaceButton,
@@ -97,6 +98,12 @@ function Examples() {
           notes="Add a new workspace to the list of possible workspaces"
         >
           <AddWorkspaceForm />
+        </Example>
+        <Example
+          title={'InvitationRedemptionForm'}
+          notes={'Add a workspace using an Earthstar invitation code'}
+        >
+          <InvitationRedemptionForm />
         </Example>
         <Example
           title={'RemoveWorkspaceButton'}

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "**/@typescript-eslint/parser": "^4.1.1"
   },
   "dependencies": {
+    "@reach/alert": "^0.11.2",
     "@reach/auto-id": "^0.11.2",
     "@reach/descendants": "0.11.2",
     "@reach/utils": "^0.11.2",

--- a/src/components/InvitationCreatorForm.tsx
+++ b/src/components/InvitationCreatorForm.tsx
@@ -43,13 +43,8 @@ export default function InvitationCreatorForm({
       </button>
       {pubs.length > 0 ? (
         <dl data-react-earthstar-invitation-creator-pub-options>
-          <dt
-            data-react-earthstar-invitation-creator-pubs-label
-            data-react-earthstar-label
-          >
-            {'Included pubs'}
-          </dt>
-          <dd>
+          <dt data-react-earthstar-dt>{'Included pubs'}</dt>
+          <dd data-react-earthstar-dd>
             {pubs.map(pubUrl => (
               <div key={pubUrl}>
                 <input

--- a/src/components/InvitationCreatorForm.tsx
+++ b/src/components/InvitationCreatorForm.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { useMakeInvitation, useWorkspacePubs, WorkspaceLabel } from '..';
+
+export default function InvitationCreatorForm({
+  workspace,
+}: {
+  workspace: string;
+}) {
+  const [pubs] = useWorkspacePubs(workspace);
+  const [excludedPubs, setExcludedPubs] = React.useState(pubs);
+  const [copied, setCopied] = React.useState(false);
+  const invitationCode = useMakeInvitation(workspace, excludedPubs);
+
+  React.useEffect(() => {
+    let id = setTimeout(() => setCopied(false), 2000);
+    return () => clearTimeout(id);
+  }, [copied]);
+
+  return (
+    <div data-react-earthstar-invitation-creator-form>
+      <input
+        data-react-earthstar-invitation-creator-input
+        data-react-earthstar-input
+        value={invitationCode}
+        disabled={true}
+      />
+      <button
+        data-react-earthstar-invitation-creator-button
+        data-react-earthstar-button
+        onClick={() => {
+          navigator.clipboard.writeText(invitationCode);
+          setCopied(true);
+        }}
+      >
+        {copied ? (
+          'Copied!'
+        ) : (
+          <>
+            {'Copy invitation code for '}
+            <WorkspaceLabel address={workspace} />
+          </>
+        )}
+      </button>
+      {pubs.length > 0 ? (
+        <dl data-react-earthstar-invitation-creator-pub-options>
+          <dt
+            data-react-earthstar-invitation-creator-pubs-label
+            data-react-earthstar-label
+          >
+            {'Included pubs'}
+          </dt>
+          <dd>
+            {pubs.map(pubUrl => (
+              <div key={pubUrl}>
+                <input
+                  data-react-earthstar-checkbox
+                  id={`react-earthstar-invitation-${pubUrl}-option`}
+                  type="checkbox"
+                  checked={!excludedPubs.includes(pubUrl)}
+                  onChange={() => {
+                    const isExcluded = excludedPubs.includes(pubUrl);
+
+                    if (isExcluded) {
+                      return setExcludedPubs(pubs =>
+                        pubs.filter(url => url !== pubUrl)
+                      );
+                    }
+
+                    setExcludedPubs(pubs => [...pubs, pubUrl]);
+                  }}
+                />
+                <label htmlFor={`react-earthstar-invitation-${pubUrl}-option`}>
+                  {pubUrl}
+                </label>
+              </div>
+            ))}
+          </dd>
+        </dl>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/InvitationRedemptionForm.tsx
+++ b/src/components/InvitationRedemptionForm.tsx
@@ -70,7 +70,7 @@ export default function InvitationRedemptionForm() {
         data-react-earthstar-invitation-code-label
         data-react-earthstar-label
       >
-        {'Invitation code'}
+        {'Redeem invitation code'}
       </label>
       <input
         data-react-earthstar-invitation-code-input
@@ -88,7 +88,7 @@ export default function InvitationRedemptionForm() {
         <dl data-react-earthstar-invitation-description>
           <dt data-react-earthstar-dt>{'Workspace'}</dt>
           <dd data-react-earthstar-dl>
-            <WorkspaceLabel address={result.workspace} />
+            {result.workspace}
             {workspaces.includes(result.workspace) ? ' (already added)' : null}
           </dd>
           <dt data-react-earthstar-dt>{'Pubs'}</dt>
@@ -135,14 +135,16 @@ export default function InvitationRedemptionForm() {
           </dd>
         </dl>
       ) : null}
-      <button
-        data-react-earthstar-invitation-redemption-button
-        data-react-earthstar-button
-        type={'submit'}
-        disabled={isThereAnythingToAdd === false}
-      >
-        {getButtonLabel()}
-      </button>
+      {code.length > 0 ? (
+        <button
+          data-react-earthstar-invitation-redemption-button
+          data-react-earthstar-button
+          type={'submit'}
+          disabled={isThereAnythingToAdd === false}
+        >
+          {getButtonLabel()}
+        </button>
+      ) : null}
     </form>
   );
 }

--- a/src/components/InvitationRedemptionForm.tsx
+++ b/src/components/InvitationRedemptionForm.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import { isErr } from 'earthstar';
+import Alert from '@reach/alert';
+import { useInvitation, useWorkspaces, usePubs } from '../hooks';
+import { WorkspaceLabel } from '../components';
+
+export default function InvitationRedemptionForm() {
+  const workspaces = useWorkspaces();
+  const [pubs] = usePubs();
+  const [code, setCode] = React.useState('');
+  const result = useInvitation(code);
+
+  const [uncheckedPubs, setUncheckedPubs] = React.useState<string[]>([]);
+
+  const preexistingPubs = isErr(result) ? [] : pubs[result.workspace] || [];
+
+  const excludedPubs = Array.from(
+    new Set([...uncheckedPubs, ...preexistingPubs])
+  );
+
+  const isThereAnythingToAdd = isErr(result)
+    ? false
+    : !workspaces.includes(result.workspace) ||
+      result.pubs.length - excludedPubs.length > 0;
+
+  const getButtonLabel = () => {
+    if (isErr(result)) {
+      return 'Add workspace';
+    }
+
+    const pubCount = result.pubs.length - excludedPubs.length;
+
+    if (workspaces.includes(result.workspace)) {
+      return (
+        <>
+          {`Add ${pubCount} pub${pubCount !== 1 ? 's' : ''} to `}
+          <WorkspaceLabel address={result.workspace} />
+        </>
+      );
+    }
+
+    const pubsSuffix =
+      pubCount === 0
+        ? ' with no pubs'
+        : ` and ${pubCount} pub${pubCount > 1 ? 's' : ''}`;
+
+    return (
+      <>
+        {'Add '}
+        <WorkspaceLabel address={result.workspace} />
+        {`${pubsSuffix}`}
+      </>
+    );
+  };
+
+  return (
+    <form
+      data-react-earthstar-invitatiton-redemption-form
+      onSubmit={e => {
+        e.preventDefault();
+
+        if (!isErr(result)) {
+          result.redeem(excludedPubs);
+          setCode('');
+          setUncheckedPubs([]);
+        }
+      }}
+    >
+      <label
+        data-react-earthstar-invitation-code-label
+        data-react-earthstar-label
+      >
+        {'Invitation code'}
+      </label>
+      <input
+        data-react-earthstar-invitation-code-input
+        data-react-earthstar-input
+        value={code}
+        onChange={e => setCode(e.target.value)}
+        placeholder={'earthstar:///?workspace=...'}
+      />
+      {isErr(result) && code.length > 0 ? (
+        <Alert data-react-earthstar-invitation-code-alert>
+          {result.message}
+        </Alert>
+      ) : null}
+      {!isErr(result) ? (
+        <dl data-react-earthstar-invitation-description>
+          <dt data-react-earthstar-dt>{'Workspace'}</dt>
+          <dd data-react-earthstar-dl>
+            <WorkspaceLabel address={result.workspace} />
+            {workspaces.includes(result.workspace) ? ' (already added)' : null}
+          </dd>
+          <dt data-react-earthstar-dt>{'Pubs'}</dt>
+          <dd data-react-earthstar-dl>
+            {result.pubs.length > 0
+              ? result.pubs.map(pubUrl => (
+                  <div key={pubUrl}>
+                    <input
+                      data-react-earthstar-checkbox
+                      id={`react-earthstar-invitation-${pubUrl}-option`}
+                      type="checkbox"
+                      disabled={preexistingPubs.includes(pubUrl)}
+                      checked={
+                        !excludedPubs.includes(pubUrl) ||
+                        preexistingPubs.includes(pubUrl)
+                      }
+                      onChange={() => {
+                        if (preexistingPubs.includes(pubUrl)) {
+                          return;
+                        }
+
+                        const isExcluded = excludedPubs.includes(pubUrl);
+
+                        if (isExcluded) {
+                          return setUncheckedPubs(pubs =>
+                            pubs.filter(url => url !== pubUrl)
+                          );
+                        }
+
+                        setUncheckedPubs(pubs => [...pubs, pubUrl]);
+                      }}
+                    />
+                    <label
+                      htmlFor={`react-earthstar-invitation-${pubUrl}-option`}
+                    >
+                      {pubUrl}
+                      {pubs[result.workspace]?.includes(pubUrl)
+                        ? ' (already added)'
+                        : null}
+                    </label>
+                  </div>
+                ))
+              : 'No pubs will be added'}
+          </dd>
+        </dl>
+      ) : null}
+      <button
+        data-react-earthstar-invitation-redemption-button
+        data-react-earthstar-button
+        type={'submit'}
+        disabled={isThereAnythingToAdd === false}
+      >
+        {getButtonLabel()}
+      </button>
+    </form>
+  );
+}

--- a/src/components/InvitationRedemptionForm.tsx
+++ b/src/components/InvitationRedemptionForm.tsx
@@ -33,14 +33,16 @@ export default function InvitationRedemptionForm() {
     if (workspaces.includes(result.workspace)) {
       return (
         <>
-          {`Add ${pubCount} pub${pubCount !== 1 ? 's' : ''} to `}
+          {`Add ${pubCount <= 0 ? 'no' : pubCount} pub${
+            pubCount !== 1 ? 's' : ''
+          } to `}
           <WorkspaceLabel address={result.workspace} />
         </>
       );
     }
 
     const pubsSuffix =
-      pubCount === 0
+      pubCount <= 0
         ? ' with no pubs'
         : ` and ${pubCount} pub${pubCount > 1 ? 's' : ''}`;
 
@@ -87,12 +89,12 @@ export default function InvitationRedemptionForm() {
       {!isErr(result) ? (
         <dl data-react-earthstar-invitation-description>
           <dt data-react-earthstar-dt>{'Workspace'}</dt>
-          <dd data-react-earthstar-dl>
+          <dd data-react-earthstar-dd>
             {result.workspace}
             {workspaces.includes(result.workspace) ? ' (already added)' : null}
           </dd>
           <dt data-react-earthstar-dt>{'Pubs'}</dt>
-          <dd data-react-earthstar-dl>
+          <dd data-react-earthstar-dd>
             {result.pubs.length > 0
               ? result.pubs.map(pubUrl => (
                   <div key={pubUrl}>

--- a/src/components/earthbar/MultiWorkspaceManagerPanel.tsx
+++ b/src/components/earthbar/MultiWorkspaceManagerPanel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { EarthbarTabPanel } from './Earthbar';
-import { AddWorkspaceForm, WorkspaceLabel } from '..';
+import { InvitationRedemptionForm, WorkspaceLabel } from '..';
 import { useWorkspaces, useSync } from '../..';
 import { WorkspaceOptions } from './WorkspaceOptions';
 
@@ -86,8 +86,8 @@ function WorkspaceList({
       </section>
       <hr />
       <section>
-        <h2>{'Add a workspace'}</h2>
-        <AddWorkspaceForm />
+        <h2>{'Join a workspace'}</h2>
+        <InvitationRedemptionForm />
       </section>
     </div>
   );

--- a/src/components/earthbar/WorkspaceManagerPanel.tsx
+++ b/src/components/earthbar/WorkspaceManagerPanel.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { EarthbarTabPanel } from './Earthbar';
 import { WorkspaceOptions } from './WorkspaceOptions';
-import { CurrentWorkspaceSelect } from '..';
+import { CurrentWorkspaceSelect, InvitationRedemptionForm } from '..';
 import { useCurrentWorkspace } from '../..';
 
 export default function WorkspaceManager() {
@@ -14,7 +14,10 @@ export default function WorkspaceManager() {
       {currentWorkspace ? (
         <WorkspaceOptions address={currentWorkspace} />
       ) : (
-        'Select a workspace above to change that workspaces identity settings, pubs, and more.'
+        <>
+          <h2>{'Join a workspace'}</h2>
+          <InvitationRedemptionForm />
+        </>
       )}
     </EarthbarTabPanel>
   );

--- a/src/components/earthbar/WorkspaceOptions.tsx
+++ b/src/components/earthbar/WorkspaceOptions.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { PubEditor, DisplayNameForm, RemoveWorkspaceButton } from '..';
+import {
+  PubEditor,
+  DisplayNameForm,
+  RemoveWorkspaceButton,
+  InvitationCreatorForm,
+} from '..';
 
 export function WorkspaceOptions({ address }: { address: string }) {
   return (
@@ -14,6 +19,11 @@ export function WorkspaceOptions({ address }: { address: string }) {
         <h2>{'Pubs'}</h2>
         <p>{'Control where this workspace syncs its data to and from.'}</p>
         <PubEditor workspace={address} />
+      </section>
+      <hr />
+      <section>
+        <h2>{'Invite others'}</h2>
+        <InvitationCreatorForm workspace={address} />
       </section>
       <hr />
       <section>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,6 +6,7 @@ export { default as CurrentAuthor } from './CurrentAuthor';
 export { default as DisplayNameForm } from './DisplayNameForm';
 export { default as DownloadKeypairButton } from './DownloadKeypairButton';
 export { default as InvitationRedemptionForm } from './InvitationRedemptionForm';
+export { default as InvitationCreatorForm } from './InvitationCreatorForm';
 export { default as NewKeypairForm } from './NewKeypairForm';
 export { default as PubEditor } from './PubEditor';
 export { default as RemoveWorkspaceButton } from './RemoveWorkspaceButton';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,6 +5,7 @@ export { default as AuthorLabel } from './AuthorLabel';
 export { default as CurrentAuthor } from './CurrentAuthor';
 export { default as DisplayNameForm } from './DisplayNameForm';
 export { default as DownloadKeypairButton } from './DownloadKeypairButton';
+export { default as InvitationRedemptionForm } from './InvitationRedemptionForm';
 export { default as NewKeypairForm } from './NewKeypairForm';
 export { default as PubEditor } from './PubEditor';
 export { default as RemoveWorkspaceButton } from './RemoveWorkspaceButton';

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -478,7 +478,7 @@ export function useSubscribeToStorages(options: {
 
 export function useInvitation(invitationCode: string) {
   const add = useAddWorkspace();
-  const [, setPubs] = usePubs();
+  const [existingPubs, setPubs] = usePubs();
 
   try {
     const url = new URL(invitationCode);
@@ -523,9 +523,24 @@ export function useInvitation(invitationCode: string) {
       return new EarthstarError('Malformed Pub URL found');
     }
 
-    const redeem = () => {
+    const redeem = (excludedPubs: string[] = []) => {
       add(plussedWorkspace);
-      setPubs(prevPubs => ({ ...prevPubs, [plussedWorkspace]: pubs }));
+
+      // In case the workspace in the invitation already has known pubs
+      // We want to keep those around.
+      const existingWorkspacePubs = existingPubs[plussedWorkspace] || [];
+
+      const nextPubs = Array.from(
+        new Set([
+          ...existingWorkspacePubs,
+          ...pubs.filter(pubUrl => !excludedPubs.includes(pubUrl)),
+        ])
+      );
+
+      setPubs(prevPubs => ({
+        ...prevPubs,
+        [plussedWorkspace]: nextPubs,
+      }));
     };
 
     return { redeem, workspace: plussedWorkspace, pubs };

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -548,3 +548,15 @@ export function useInvitation(invitationCode: string) {
     return new EarthstarError('Not a valid Earthstar URL');
   }
 }
+
+export function useMakeInvitation(
+  workspace: string,
+  excludedPubs: string[] = []
+) {
+  const [pubs] = useWorkspacePubs(workspace);
+
+  const pubsToUse = pubs.filter(pubUrl => !excludedPubs.includes(pubUrl));
+  const pubsString = pubsToUse.map(pubUrl => `&pub=${pubUrl}`).join('');
+
+  return `earthstar:///?workspace=${workspace}${pubsString}&v=1`;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -67,6 +67,34 @@
   grid-area: button;
 }
 
+/* InvitationRedemptionForm */
+
+[data-react-earthstar-invitatiton-redemption-form] {
+  display: grid;
+  grid-template-areas: 'label' 'input' 'error' 'description' 'button';
+  grid-template-columns: 1fr
+}
+
+[data-react-earthstar-invitation-code-label] {
+  grid-area: label
+}
+
+[data-react-earthstar-invitation-code-input] {
+  grid-area: input
+}
+
+[data-react-earthstar-invitation-code-alert] {
+  grid-area: error
+}
+
+[data-react-earthstar-invitation-description] {
+  grid-area: description;
+}
+
+[data-react-earthstar-invitation-redemption-button] {
+  grid-area: button
+}
+
 /* NewKeypairForm */
 
 [data-react-earthstar-keypair-form-shortname-label] {

--- a/src/styles.css
+++ b/src/styles.css
@@ -67,6 +67,26 @@
   grid-area: button;
 }
 
+/* InvitationCreatorForm */
+
+[data-react-earthstar-invitation-creator-form] {
+  display: grid;
+  grid-template-areas: 'input input input button' 'pub-options pub-options pub-options pub-options';
+  grid-template-columns: 1fr 1fr 1fr 1fr
+}
+
+[data-react-earthstar-invitation-creator-input] {
+  grid-area: input;
+}
+
+[data-react-earthstar-invitation-creator-button] {
+  grid-area: button;
+}
+
+[data-react-earthstar-invitation-creator-pub-options] {
+  grid-area: pub-options
+}
+
 /* InvitationRedemptionForm */
 
 [data-react-earthstar-invitatiton-redemption-form] {

--- a/src/warp.css
+++ b/src/warp.css
@@ -86,6 +86,15 @@
   background: var(--ac2);
 }
 
+[data-react-earthstar-button]:disabled {
+  opacity: 0.5;
+}
+
+[data-react-earthstar-button]:disabled:hover {
+  background: var(--ac2);
+}
+
+
 [data-react-earthstar-input] {
   font-family: 'Gill Sans';
   font-size: 14px;

--- a/test/hooks.test.tsx
+++ b/test/hooks.test.tsx
@@ -23,6 +23,7 @@ import {
   useSubscribeToStorages,
   useCurrentWorkspace,
   useInvitation,
+  useMakeInvitation,
 } from '../src';
 
 const keypair = generateAuthorKeypair('onee') as AuthorKeypair;
@@ -466,5 +467,29 @@ test('useInvitation', () => {
 
   expect((result.current.invitationResult as EarthstarError).message).toEqual(
     'Not a valid Earthstar URL'
+  );
+});
+
+test('useMakeInvitation', () => {
+  const useTest = () => {
+    const [workspace, setWorkspace] = React.useState(WORKSPACE_ADDR_A);
+    const [excludedPubs, setExcludedPubs] = React.useState<string[]>([]);
+    const invitationCode = useMakeInvitation(workspace, excludedPubs);
+
+    return { setWorkspace, setExcludedPubs, invitationCode };
+  };
+
+  const { result } = renderHook(() => useTest(), { wrapper });
+
+  expect(result.current.invitationCode).toEqual(
+    'earthstar:///?workspace=+testa.a123&pub=https://a.pub&v=1'
+  );
+
+  act(() => {
+    result.current.setExcludedPubs([PUB_A]);
+  });
+
+  expect(result.current.invitationCode).toEqual(
+    'earthstar:///?workspace=+testa.a123&v=1'
   );
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1229,6 +1229,16 @@
     "@parcel/utils" "^1.11.0"
     physical-cpu-count "^2.0.0"
 
+"@reach/alert@^0.11.2":
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/@reach/alert/-/alert-0.11.2.tgz#7712a1ac2380d9426a0fe202a2fc48b976548bff"
+  integrity sha512-udMiJ+MR97ZcPxwc4CNSs6FvXfjiS/Q1mL61fbONSPSkN4GFSWkYy2WvXH5pZfg1DbEscRNGa7E8bgJfGiVo1g==
+  dependencies:
+    "@reach/utils" "0.11.2"
+    "@reach/visually-hidden" "0.11.1"
+    prop-types "^15.7.2"
+    tslib "^2.0.0"
+
 "@reach/auto-id@^0.11.2":
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.11.2.tgz#c66a905c5401d1ac3da8d26165b8d27d6e778fa6"
@@ -1253,6 +1263,13 @@
     "@types/warning" "^3.0.0"
     tslib "^2.0.0"
     warning "^4.0.3"
+
+"@reach/visually-hidden@0.11.1":
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/@reach/visually-hidden/-/visually-hidden-0.11.1.tgz#3d7a5742acf18372f35b9e216680edd8073f35e3"
+  integrity sha512-TZZNSttor2jG6ZPGI35s/8G0FNSz49QrJIhAZbnUqHyPf3+jtNqAC0dOWW8Nuk+mApDDDVYd2KZ9P2vnzllNnQ==
+  dependencies:
+    tslib "^2.0.0"
 
 "@rollup/plugin-babel@^5.1.0":
   version "5.2.1"


### PR DESCRIPTION
Adds UI for handling Earthstar invitation codes as detailed in https://github.com/earthstar-project/earthstar/issues/36

- An InvitationRedemptionForm for adding a workspace and pubs with an invitation code
- An InvitationCreationForm for creating an invitation from a given workspace
- Work both of these into Earthbar

Closes #23 