### PR TITLE
PubEditor: Fix href to pubUrl

### DIFF
--- a/src/components/PubEditor.tsx
+++ b/src/components/PubEditor.tsx
@@ -27,7 +27,7 @@ export default function PubEditor({ workspace }: { workspace: string }) {
           {pubs.map(pubUrl => {
             return (
               <li data-react-earthstar-pubeditor-list-item key={`${pubUrl}`}>
-                <a href={'pubUrl'}>{pubUrl}</a>
+                <a href={pubUrl}>{pubUrl}</a>
                 <button
                   data-react-earthstar-pubeditor-list-item-delete-button
                   data-react-earthstar-button


### PR DESCRIPTION
https://github.com/earthstar-project/react-earthstar/blob/f53a632265c2f24425ccb3ae8d7269c64ad337c1/src/components/PubEditor.tsx#L30

I think this needs the quotes removed so it links to the actual pub url and not `"pubUrl"`