### PR TITLE
Make workspace address optional in hooks, components

### DIFF
--- a/examples/components/index.tsx
+++ b/examples/components/index.tsx
@@ -115,7 +115,7 @@ function Examples() {
           title={'InvitationCreatorForm'}
           notes={'Create Earthstar invitation code from a workspace'}
         >
-          <InvitationCreatorForm workspace={EXAMPLE_WORKSPACE_ADDR1} />
+          <InvitationCreatorForm workspaceAddress={EXAMPLE_WORKSPACE_ADDR1} />
         </Example>
         <Example
           title={'RemoveWorkspaceButton'}
@@ -129,7 +129,7 @@ function Examples() {
           title={'PubEditor'}
           notes="Add or remove pubs from a given workspace."
         >
-          <PubEditor workspace={EXAMPLE_WORKSPACE_ADDR1} />
+          <PubEditor workspaceAddress={EXAMPLE_WORKSPACE_ADDR1} />
         </Example>
         <Example title={'WorkspaceList'} notes="List the known workspaces">
           <WorkspaceList />
@@ -174,7 +174,7 @@ function Examples() {
           title={'DisplayNameForm'}
           notes="Change the display name of the currently signed in author, in a given workspace"
         >
-          <DisplayNameForm workspace={EXAMPLE_WORKSPACE_ADDR1} />
+          <DisplayNameForm workspaceAddress={EXAMPLE_WORKSPACE_ADDR1} />
         </Example>
         <hr />
         <h2>Stateless helpers</h2>

--- a/src/components/DisplayNameForm.tsx
+++ b/src/components/DisplayNameForm.tsx
@@ -3,11 +3,15 @@ import { WorkspaceLabel } from '.';
 import { useDocument, useCurrentAuthor } from '../hooks';
 import { getAuthorShortName } from '../util';
 
-export default function DisplayNameForm({ workspace }: { workspace: string }) {
+export default function DisplayNameForm({
+  workspaceAddress,
+}: {
+  workspaceAddress?: string;
+}) {
   const [currentAuthor] = useCurrentAuthor();
   const [displayNameDoc, setDisplayNameDoc] = useDocument(
-    workspace,
-    `/about/~${currentAuthor?.address}/displayName.txt`
+    `/about/~${currentAuthor?.address}/displayName.txt`,
+    workspaceAddress
   );
 
   const [newDisplayName, setNewDisplayName] = React.useState(
@@ -32,10 +36,10 @@ export default function DisplayNameForm({ workspace }: { workspace: string }) {
       <label
         data-react-earthstar-display-name-label
         data-react-earthstar-label
-        htmlFor={`author-display-name-${workspace}`}
+        htmlFor={`author-display-name-${workspaceAddress}`}
       >
         {'Your display name in '}
-        <WorkspaceLabel address={workspace} />
+        <WorkspaceLabel address={workspaceAddress || 'nowhere'} />
       </label>
       <input
         data-react-earthstar-display-name-input

--- a/src/components/InvitationCreatorForm.tsx
+++ b/src/components/InvitationCreatorForm.tsx
@@ -2,15 +2,15 @@ import React from 'react';
 import { useMakeInvitation, useWorkspacePubs } from '..';
 
 export default function InvitationCreatorForm({
-  workspace,
+  workspaceAddress,
 }: {
-  workspace: string;
+  workspaceAddress?: string;
 }) {
-  const [pubs] = useWorkspacePubs(workspace);
+  const [pubs] = useWorkspacePubs(workspaceAddress);
   // include all pubs by default (exclude none)
   const [excludedPubs, setExcludedPubs] = React.useState<string[]>([]);
   const [copied, setCopied] = React.useState(false);
-  const invitationCode = useMakeInvitation(workspace, excludedPubs);
+  const invitationCode = useMakeInvitation(excludedPubs, workspaceAddress);
 
   React.useEffect(() => {
     let id = setTimeout(() => setCopied(false), 2000);

--- a/src/components/PubEditor.tsx
+++ b/src/components/PubEditor.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
 import { useWorkspacePubs } from '../hooks';
 
-export default function PubEditor({ workspace }: { workspace: string }) {
+export default function PubEditor({
+  workspaceAddress,
+}: {
+  workspaceAddress?: string;
+}) {
   const [pubToAdd, setPubToAdd] = React.useState('');
-  const [pubs, setPubs] = useWorkspacePubs(workspace);
+  const [pubs, setPubs] = useWorkspacePubs(workspaceAddress);
 
   const removePub = React.useCallback(
     (pubToRemove: string) => {

--- a/src/components/RemoveWorkspaceButton.tsx
+++ b/src/components/RemoveWorkspaceButton.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
-import { useRemoveWorkspace } from '../hooks';
+import { useCurrentWorkspace, useRemoveWorkspace } from '../hooks';
 
 export default function RemoveWorkspaceButton({
   workspaceAddress,
   children,
   ...props
-}: { workspaceAddress: string } & React.HTMLAttributes<HTMLButtonElement>) {
+}: { workspaceAddress?: string } & React.HTMLAttributes<HTMLButtonElement>) {
   const remove = useRemoveWorkspace();
+  const [currentWorkspace] = useCurrentWorkspace();
+
+  const address = workspaceAddress || currentWorkspace;
 
   return (
     <button
@@ -14,16 +17,20 @@ export default function RemoveWorkspaceButton({
       data-react-earthstar-button
       {...props}
       onClick={() => {
+        if (!address) {
+          return;
+        }
+
         const isSure = window.confirm(
-          `Are you sure you want to remove ${workspaceAddress} from your workspaces?`
+          `Are you sure you want to remove ${address} from your workspaces?`
         );
 
         if (isSure) {
-          remove(workspaceAddress);
+          remove(address);
         }
       }}
     >
-      {children || `Remove ${workspaceAddress}`}
+      {children || `Remove ${address}`}
     </button>
   );
 }

--- a/src/components/earthbar/MultiWorkspaceManagerPanel.tsx
+++ b/src/components/earthbar/MultiWorkspaceManagerPanel.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { EarthbarTabPanel } from './Earthbar';
 import { WorkspaceLabel, SyncingCheckbox } from '..';
-import { useWorkspaces, useSync } from '../..';
+import { useWorkspaces } from '../..';
 import { WorkspaceOptions } from './WorkspaceOptions';
 
 type WorkspaceManagerState =
@@ -32,8 +32,6 @@ function WorkspaceRow({
   address: string;
   navToWorkspace: () => void;
 }) {
-  const sync = useSync();
-
   return (
     <li data-react-earthstar-workspace-row>
       <div>
@@ -41,21 +39,13 @@ function WorkspaceRow({
           data-react-earthstar-workspace-row-address
           address={address}
         />
-        <button
-          data-react-earthstar-multiworkspace-settings-button
-          data-react-earthstar-button
-          onClick={navToWorkspace}
-        >
-          {'Settings'}
-        </button>
       </div>
-      {/* TODO: Replace this with a checkbox which toggles live syncing individually */}
       <button
-        data-react-earthstar-workspace-row-sync
+        data-react-earthstar-multiworkspace-settings-button
         data-react-earthstar-button
-        onClick={() => sync(address)}
+        onClick={navToWorkspace}
       >
-        {'Sync'}
+        {'Settings'}
       </button>
     </li>
   );
@@ -112,7 +102,7 @@ export default function MultiWorkspaceManagerPanel() {
             {state.address}
           </nav>
           <hr />
-          <WorkspaceOptions address={state.address} />
+          <WorkspaceOptions workspaceAddress={state.address} />
         </div>
       )}
     </EarthbarTabPanel>

--- a/src/components/earthbar/UserPanel.tsx
+++ b/src/components/earthbar/UserPanel.tsx
@@ -26,7 +26,7 @@ export default function UserPanel() {
         <>
           <hr />
           <section>
-            <DisplayNameForm workspace={currentWorkspace} />
+            <DisplayNameForm workspaceAddress={currentWorkspace} />
           </section>
         </>
       ) : null}

--- a/src/components/earthbar/WorkspaceManagerPanel.tsx
+++ b/src/components/earthbar/WorkspaceManagerPanel.tsx
@@ -14,14 +14,13 @@ export default function WorkspaceManager() {
           <h2>{currentWorkspace}</h2>
           <SyncingCheckbox />
           <hr />
-          <WorkspaceOptions address={currentWorkspace} />
+          <WorkspaceOptions />
         </>
       ) : (
         <>
           <h2>{'Join a workspace'}</h2>
           <InvitationRedemptionForm
             onRedeem={workspace => {
-              console.log(workspace);
               setTimeout(() => {
                 setCurrentWorkspace(workspace);
               });

--- a/src/components/earthbar/WorkspaceOptions.tsx
+++ b/src/components/earthbar/WorkspaceOptions.tsx
@@ -1,18 +1,22 @@
 import React from 'react';
 import { PubEditor, RemoveWorkspaceButton, InvitationCreatorForm } from '..';
 
-export function WorkspaceOptions({ address }: { address: string }) {
+export function WorkspaceOptions({
+  workspaceAddress,
+}: {
+  workspaceAddress?: string;
+}) {
   return (
     <div data-react-earthstar-earthbar-workspace-options>
       <details data-react-earthstar-details>
         <summary data-react-earthstar-summary>{'Pubs'}</summary>
         <p>{'Control where this workspace syncs its data to and from.'}</p>
-        <PubEditor workspace={address} />
+        <PubEditor workspaceAddress={workspaceAddress} />
       </details>
       <hr />
       <details data-react-earthstar-details>
         <summary data-react-earthstar-summary>{'Invite others'}</summary>
-        <InvitationCreatorForm workspace={address} />
+        <InvitationCreatorForm workspaceAddress={workspaceAddress} />
       </details>
       <hr />
       <details data-react-earthstar-details>
@@ -22,7 +26,7 @@ export function WorkspaceOptions({ address }: { address: string }) {
             'Your local copy of the workspace will be removed, but will remain with other pubs and peers it has been synced to.'
           }
         </p>
-        <RemoveWorkspaceButton workspaceAddress={address} />
+        <RemoveWorkspaceButton />
       </details>
     </div>
   );

--- a/test/hooks.test.tsx
+++ b/test/hooks.test.tsx
@@ -185,7 +185,7 @@ test('useCurrentWorkspace', async () => {
 test('usePaths', () => {
   const useTest = (q: QueryOpts) => {
     const [query, setQuery] = React.useState(q);
-    const paths = usePaths(WORKSPACE_ADDR_A, query);
+    const paths = usePaths(query, WORKSPACE_ADDR_A);
     const [storages] = useStorages();
 
     return { paths, storage: storages[WORKSPACE_ADDR_A], setQuery };
@@ -223,7 +223,7 @@ test('useDocument', () => {
     const [storages] = useStorages();
     const [path, setPath] = React.useState('/test/test.txt');
     const [workspace, setWorkspace] = React.useState(WORKSPACE_ADDR_A);
-    const [doc, setDoc, deleteDoc] = useDocument(workspace, path);
+    const [doc, setDoc, deleteDoc] = useDocument(path, workspace);
 
     return { setWorkspace, setPath, doc, setDoc, deleteDoc, storages };
   };
@@ -268,7 +268,7 @@ test('useDocument', () => {
 test('useDocuments', async () => {
   const useTest = (q: QueryOpts) => {
     const [query, setQuery] = React.useState(q);
-    const docs = useDocuments(WORKSPACE_ADDR_A, query);
+    const docs = useDocuments(query, WORKSPACE_ADDR_A);
     const [storages] = useStorages();
 
     return { docs, storage: storages[WORKSPACE_ADDR_A], setQuery };
@@ -530,7 +530,7 @@ test('useMakeInvitation', () => {
   const useTest = () => {
     const [workspace, setWorkspace] = React.useState(WORKSPACE_ADDR_A);
     const [excludedPubs, setExcludedPubs] = React.useState<string[]>([]);
-    const invitationCode = useMakeInvitation(workspace, excludedPubs);
+    const invitationCode = useMakeInvitation(excludedPubs, workspace);
 
     return { setWorkspace, setExcludedPubs, invitationCode };
   };


### PR DESCRIPTION
This makes it so that hooks and components with required arguments for which workspace to use **are no longer required**.

For example:

```
useDocument("+space.a123", "/my/doc.txt/")
```

becomes

```
useDocument("/my/doc.txt/")
```

This is made possible by using the value of the current workspace as the fallback.

But I'm not entirely convinced this is a good API change. I went ahead and did this work to see what it would feel like, and wanted more feedback here.

Pros:
- Less stuff to type!
- Simpler API (?)
  - Counterpoint: People now require knowledge of the current workspace concept to understand what's happening.

Cons:
- `currentWorkspace` can possibly be `null`. 
  - In which case each hook does it's best to return an 'empty result
    - Which might make things even more confusing