### PR TITLE
Log document write errors from useDocument to console

### DIFF
--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -458,12 +458,21 @@ export function useDocument(
         );
       }
 
-      return storage.set(currentAuthor, {
+      const result = storage.set(currentAuthor, {
         format: 'es.4',
         path,
         content,
         deleteAfter,
       });
+
+      if (isErr(result)) {
+        console.group();
+        console.warn(`There was a problem setting the document at ${path}:`);
+        console.warn(result.message);
+        console.groupEnd();
+      }
+
+      return result;
     },
     [path, currentAuthor, workspaceAddress, storage]
   );


### PR DESCRIPTION
If there was ever a problem with writing a document using the set function returned by `useDocument`, you wouldn't know unless you'd set up some kind of error reporting yourself.

This changes it so that write errors will be logged to the console.