### PR TITLE
Style adjustments and help text changes

### DIFF
--- a/src/components/AuthorKeypairUpload.tsx
+++ b/src/components/AuthorKeypairUpload.tsx
@@ -55,6 +55,7 @@ export default function AuthorKeypairUpload(props: AuthorKeypairUploadProps) {
         data-re-label
         htmlFor={'keypair-upload-button'}
       >
+        or{' '}
         <button
           data-re-keypair-upload-button
           data-re-button
@@ -64,7 +65,7 @@ export default function AuthorKeypairUpload(props: AuthorKeypairUploadProps) {
             }
           }}
         >
-          {'Sign in with keypair.json'}
+          {'Sign in with keypair.json file'}
         </button>
       </label>
     </>

--- a/src/components/DownloadKeypairButton.tsx
+++ b/src/components/DownloadKeypairButton.tsx
@@ -17,7 +17,7 @@ export default function DownloadKeypairButton(
       onClick={() => download(currentAuthor)}
       disabled={currentAuthor === null}
     >
-      {'Download keypair.json'}
+      {'Download keypair.json file'}
     </button>
   );
 }

--- a/src/components/InvitationRedemptionForm.tsx
+++ b/src/components/InvitationRedemptionForm.tsx
@@ -169,9 +169,8 @@ export default function InvitationRedemptionForm({
         </summary>
         <div data-re-details-content>
           <p>
-            {
-              "If you'd like to join a workspace, ask an existing member to generate an invitation code for you."
-            }
+            Ask an existing member to make an invitation code from the workspace
+            settings page.
           </p>
         </div>
       </details>

--- a/src/components/WorkspaceCreatorForm.tsx
+++ b/src/components/WorkspaceCreatorForm.tsx
@@ -19,7 +19,7 @@ function randomFromString(str: string) {
 
 function generateSuffix() {
   const firstLetter = randomFromString(LETTERS);
-  const rest = Array.from(Array(10), () =>
+  const rest = Array.from(Array(11), () =>
     randomFromString(LETTERS + NUMBERS)
   ).join('');
 
@@ -107,7 +107,7 @@ export default function WorkspaceCreatorForm({
           data-re-fieldset
           data-re-workspace-creator-initial-pubs-fieldset
         >
-          <legend data-re-legend>{'Initial pub servers to sync with'}</legend>
+          <legend data-re-legend>{'Pub servers to sync with'}</legend>
           {addedPubs.length > 0 ? (
             <ul data-re-pubs-list>
               {addedPubs.map(pubUrl => (
@@ -186,9 +186,58 @@ export default function WorkspaceCreatorForm({
         <summary data-re-summary>{'What will this form do?'}</summary>
         <div data-re-details-content>
           <p>
-            {
-              'A local copy of the workspace will be created, and its documents synced with any of the pub servers given above.'
-            }
+            A new workspace will be made on your device, and it will be synced
+            with the pub servers given above. If you don't add any pub servers,
+            your data will only exist on your own device. You can add pub
+            servers later.
+          </p>
+        </div>
+      </details>
+      <details data-re-details>
+        <summary data-re-summary>{'What are pub servers?'}</summary>
+        <div data-re-details-content>
+          <p>
+            Pub servers run in the cloud and hold a copy of the workspace data.
+            They help keep the data online so it can sync even when some
+            people's devices are turned off.
+          </p>
+          <p>
+            One workspace can use several pub servers; each will hold a complete
+            redundant copy of the data. You can add more pubs whenever you like.
+          </p>
+        </div>
+      </details>
+      <details data-re-details>
+        <summary data-re-summary>{'Where do I find pub servers?'}</summary>
+        <div data-re-details-content>
+          <p>
+            Ask your friends, or run your own using{' '}
+            <a href="https://github.com/earthstar-project/earthstar-pub#running-on-glitch">
+              these instructions.
+            </a>
+          </p>
+          <p>
+            Pub servers can see your data, so it's best to use ones run by
+            people you know and trust.
+          </p>
+        </div>
+      </details>
+      <details data-re-details>
+        <summary data-re-summary>
+          {'Who will be able to join my workspace?'}
+        </summary>
+        <div data-re-details-content>
+          <p>
+            Anyone who knows a workspace address, and at least one of its pubs,
+            can join it. They will be able to read and write data.
+          </p>
+          <p>
+            After creating your workspace, you can get an invitation code to
+            send to your friends from the workspace settings page.
+          </p>
+          <p>
+            Your workspace can also be joined by whoever is running the pubs it
+            syncs with.
           </p>
         </div>
       </details>

--- a/src/components/_CopyButton.tsx
+++ b/src/components/_CopyButton.tsx
@@ -28,7 +28,7 @@ export default function({
         setCopied(true);
       }}
     >
-      {copied ? 'Copied!' : children || 'Copy'}
+      {copied ? 'Copied to clipboard!' : children || 'Copy'}
     </button>
   );
 }

--- a/src/components/earthbar/MultiWorkspaceManagerPanel.tsx
+++ b/src/components/earthbar/MultiWorkspaceManagerPanel.tsx
@@ -78,7 +78,18 @@ function WorkspaceList({
             </ul>
           </>
         ) : (
-          <p>{'You have no workspaces. Add one.'}</p>
+          <>
+            <p>You have no workspaces saved to this device.</p>
+            <p>
+              If you have used Earthstar on another device, you will need to add
+              your workspaces again to this device. The easiest way is to send
+              yourself invitation codes.
+            </p>
+            <p>
+              It's OK to use the same workspaces and author identity on multiple
+              devices at the same time.
+            </p>
+          </>
         )}
       </section>
     </div>

--- a/src/components/earthbar/NewUserPanel.tsx
+++ b/src/components/earthbar/NewUserPanel.tsx
@@ -14,6 +14,9 @@ export default function NewUserPanel() {
           {'Make a new author identity'}
         </h1>
         <NewKeypairForm />
+        <p>
+          And be sure to <b>save your new identity on the next screen!</b>
+        </p>
         <details data-re-details>
           <summary data-re-summary>{'What is an author identity?'}</summary>
           <div data-re-details-content>
@@ -23,14 +26,9 @@ export default function NewUserPanel() {
               }
             </p>
             <p>
-              {
-                "It's made up of a public address, which starts with the four letter nickname entered above, and a secret which only you know."
-              }
-            </p>
-            <p>
-              {
-                'Using these two elements, Earthstar apps can prove you are who you say you are using cryptography.'
-              }
+              It has a public <b>address</b> made of a 4 letter nickname plus a
+              cryptographic public key, and a cryptographic <b>secret</b> that's
+              similar to a password.
             </p>
             <p>
               {
@@ -43,29 +41,8 @@ export default function NewUserPanel() {
           <summary data-re-summary>{'Can I change my nickname later?'}</summary>
           <div data-re-details-content>
             <p>
-              {
-                'No. However, your author nickname will not be the primary way you are represented in most apps.'
-              }
-            </p>
-            <p>
-              {
-                "After creating an identity you'll be able to set a display name, which can be any length, and can be changed at any time."
-              }
-            </p>
-          </div>
-        </details>
-        <details data-re-details>
-          <summary data-re-summary>{'What will this form do?'}</summary>
-          <div data-re-details-content>
-            <p>{'A new, unique identity will be created for you.'}</p>
-            <p>
-              {'After doing this, '}
-              <b>{'be sure to save your new identity on the next screen.'}</b>
-            </p>
-            <p>
-              {
-                'Either 1. Download the "keypair.json" file, or 2. Copy the address and secret to a safe place like a password manager. If you lose your login info, it can\'t be recovered.'
-              }
+              No, but after you sign in you can set a <b>display name</b> which
+              you can change whenever you like.
             </p>
           </div>
         </details>

--- a/src/components/earthbar/UserPanel.tsx
+++ b/src/components/earthbar/UserPanel.tsx
@@ -8,9 +8,11 @@ import {
   SignOutButton,
 } from '../';
 import { useCurrentWorkspace } from '../..';
+import { useCurrentAuthor } from '../../hooks';
 
 export default function UserPanel() {
   const [currentWorkspace] = useCurrentWorkspace();
+  let [keypair] = useCurrentAuthor();
 
   return (
     <EarthbarTabPanel data-re-user-panel>
@@ -26,11 +28,24 @@ export default function UserPanel() {
 
       <section data-re-user-panel-save-identity-section>
         <h1 data-re-user-panel-save-identity-title>{'Save your identity'}</h1>
-        <DownloadKeypairButton />
+        <p>Your author address:</p>
+        <div data-re-user-panel-address>
+          <code>{keypair?.address || ''}</code>
+        </div>
+        <p>Your author secret: (select it to see it)</p>
+        <div data-re-user-panel-secret>
+          <code>{keypair?.secret || ''}</code>
+        </div>
+        <hr />
         <CopyAuthorAddressButton />
         <CopyAuthorSecretButton />
+        <hr />
+        Or <DownloadKeypairButton /> containing your address and secret.
+        <hr />
         <details data-re-details>
-          <summary data-re-summary>{'Why should I save my identity?'}</summary>
+          <summary data-re-summary>
+            {'Why do I need to save my identity?'}
+          </summary>
           <div data-re-details-content>
             <p>
               {
@@ -38,12 +53,62 @@ export default function UserPanel() {
               }
             </p>
             <p>
-              {'Should this happen, you will need to generate a new identity'}
+              {'Should this happen, you will need to generate a new identity.'}
             </p>
             <p>
               {
-                'It is recommended to store your author identity address and secret or keypair.json in a password manager.'
+                'We recomment storing your author address and secret, or keypair.json, in a password manager.'
               }
+            </p>
+          </div>
+        </details>
+        <details data-re-details>
+          <summary data-re-summary>
+            {'Can I tell other people my identity?'}
+          </summary>
+          <div data-re-details-content>
+            <p>
+              It's safe to tell friends your author <b>address</b> -- the whole
+              long thing.
+            </p>
+            <p>
+              Since anyone can make an address with the same nickname as you,
+              telling people your entire address will help them know they're not
+              talking to an impostor.
+            </p>
+            <p>
+              Don't share your <b>secret</b> -- treat it like a password.
+            </p>
+          </div>
+        </details>
+        <details data-re-details>
+          <summary data-re-summary>
+            {'How does this work under the hood?'}
+          </summary>
+          <div data-re-details-content>
+            <p>
+              Your address is a cryptographic public key, and your secret is the
+              corresponding private key.
+            </p>
+            <p>
+              Your data is signed, but not encrypted, with this keypair. Anyone
+              can in the workspace can read it, but nobody can alter it or the
+              signature would become invalid.
+            </p>
+            <p>
+              Earthstar uses{' '}
+              <a href="https://github.com/earthstar-project/earthstar/blob/master/docs/specification.md#ed25519-signatures">
+                ed25519 keypairs encoded in base32.
+              </a>
+            </p>
+            <p>
+              The 4-character nickname is not part of the keypair but is
+              considered part of your distinct identity. You can make multiple
+              identities with the same keypair and different nicknames and they
+              will be considered different identities. Here's more about{' '}
+              <a href="https://github.com/earthstar-project/earthstar/blob/master/docs/specification.md#faq-author-shortnames">
+                the reasoning behind this design.
+              </a>
             </p>
           </div>
         </details>

--- a/src/components/earthbar/UserPanel.tsx
+++ b/src/components/earthbar/UserPanel.tsx
@@ -28,14 +28,16 @@ export default function UserPanel() {
 
       <section data-re-user-panel-save-identity-section>
         <h1 data-re-user-panel-save-identity-title>{'Save your identity'}</h1>
-        <p>Your author address:</p>
-        <div data-re-user-panel-address>
-          <code>{keypair?.address || ''}</code>
-        </div>
-        <p>Your author secret: (select it to see it)</p>
-        <div data-re-user-panel-secret>
-          <code>{keypair?.secret || ''}</code>
-        </div>
+        <dl>
+          <dt>Your author address:</dt>
+          <dd data-re-user-panel-address>
+            <code>{keypair?.address || ''}</code>
+          </dd>
+          <dt>Your author secret: (select it to see it)</dt>
+          <dd data-re-user-panel-secret>
+            <code>{keypair?.secret || ''}</code>
+          </dd>
+        </dl>
         <hr />
         <CopyAuthorAddressButton />
         <CopyAuthorSecretButton />

--- a/src/components/earthbar/UserPanel.tsx
+++ b/src/components/earthbar/UserPanel.tsx
@@ -57,7 +57,7 @@ export default function UserPanel() {
             </p>
             <p>
               {
-                'We recomment storing your author address and secret, or keypair.json, in a password manager.'
+                'We recommend storing your author address and secret, or keypair.json, in a password manager.'
               }
             </p>
           </div>

--- a/src/components/earthbar/WorkspaceOptions.tsx
+++ b/src/components/earthbar/WorkspaceOptions.tsx
@@ -21,7 +21,7 @@ export function WorkspaceOptions({
       <hr />
       <section data-re-section>
         <h1>{'Pub Servers'}</h1>
-        <p>{'Cloud servers that help this workspace sync its data.'}</p>
+        <p>{'Servers that help this workspace sync its data.'}</p>
         <PubEditor workspaceAddress={workspaceAddress} />
       </section>
       <hr />

--- a/src/components/earthbar/WorkspaceOptions.tsx
+++ b/src/components/earthbar/WorkspaceOptions.tsx
@@ -20,15 +20,15 @@ export function WorkspaceOptions({
       </section>
       <hr />
       <section data-re-section>
-        <h1>{'Pubs'}</h1>
-        <p>{'Manage where this workspace syncs its data to and from.'}</p>
+        <h1>{'Pub Servers'}</h1>
+        <p>{'Cloud servers that help this workspace sync its data.'}</p>
         <PubEditor workspaceAddress={workspaceAddress} />
       </section>
       <hr />
       <section data-re-section>
-        <h1>{'Invite others'}</h1>
+        <h1>{'Invite People'}</h1>
         <p>
-          {'Generate invitation codes others can use to join this workspace.'}
+          {'Send this code to your friends so they can join the workspace.'}
         </p>
         <InvitationCreatorForm workspaceAddress={workspaceAddress} />
       </section>
@@ -36,9 +36,14 @@ export function WorkspaceOptions({
       <section data-re-section>
         <h1>{'Danger Zone'}</h1>
         <p>
-          {
-            'Your local copy of the workspace will be removed, but will remain with other pubs and peers it has been synced to.'
-          }
+          You can remove your copy of the workspace from this device, but it
+          will remain with pubs and other users it has synced with.
+        </p>
+        <p>
+          It's not possible to globally delete a workspace, but you can delete
+          your own data out of a workspace if the app allows it. If you do that,
+          make sure to give your deletions time to sync with the pubs before you
+          remove the entire workspace.
         </p>
         <RemoveWorkspaceButton onClick={onRemove} />
       </section>

--- a/src/components/earthbar/WorkspaceTab.tsx
+++ b/src/components/earthbar/WorkspaceTab.tsx
@@ -41,7 +41,7 @@ export default function WorkspaceTab() {
       </select>
       {selectedOption !== 'ADD_WORKSPACE' ? (
         <EarthbarTab data-re-earthbar-workspace-select-tab>
-          <EarthbarTabLabel>{'Settings'}</EarthbarTabLabel>
+          <EarthbarTabLabel>{'Workspace settings'}</EarthbarTabLabel>
           <WorkspaceManagerPanel />
         </EarthbarTab>
       ) : (

--- a/styles/junior.css
+++ b/styles/junior.css
@@ -1,5 +1,5 @@
 :root {
-  --gr6: #f4eed4;
+  --gr6: #faf4da;
   --gr5: #c8bfae;
   --gr4: #a0948b;
   --gr3: #7e706e;
@@ -21,6 +21,7 @@
 }
 
 [data-re-earthbar-panel] code {
+  font-size: 1.2em;
   color: var(--ac2);
   font-weight: bold;
 }
@@ -182,7 +183,7 @@
   font-family: var(--t1);
   font-size: 1em;
   padding: 6px;
-  border: 1px solid var(--gr5);
+  border: 1px solid var(--gr4);
   border-radius: 4px;
 }
 
@@ -219,10 +220,9 @@
 
 [data-re-summary] {
   color: var(--gr2);
-  /* display: inline-block; */ /* hide the triangle */
   padding: 2px;
   position: relative;
-  /* border-bottom: 1px solid var(--gr5); */
+  text-decoration: underline;
 }
 
 [data-re-summary]:hover {
@@ -231,7 +231,7 @@
 }
 
 [data-re-details-content] {
-  padding: 8px 0;
+  padding: 8px 0 0 20px;
 }
 
 [data-re-details-content] p {
@@ -369,6 +369,13 @@
   color: var(--gr4) !important;
   background-color: var(--gr4) !important;
 }
+
+dd[data-re-user-panel-address],
+dd[data-re-user-panel-secret] {
+  margin: 0.5em 0;
+  padding-left: 10px;
+}
+
 [data-re-user-panel-secret] code::selection {
   color: white;
   background-color: black;

--- a/styles/junior.css
+++ b/styles/junior.css
@@ -134,9 +134,8 @@
   background-repeat: no-repeat, repeat;
   background-position: right 6px top 50%, 0 0;
   background-size: 0.65em auto, 100%;
-  box-shadow: var(--sh)
+  box-shadow: var(--sh);
 }
-
 
 [data-re-button] {
   font-family: var(--t1);
@@ -188,7 +187,8 @@
 }
 
 [data-re-label],
-[data-re-legend], [data-re-dt] {
+[data-re-legend],
+[data-re-dt] {
   color: var(--gr3);
   margin: 0 0 2px 0;
 }
@@ -203,9 +203,13 @@
 
 [data-re-fieldset] {
   border: 0px solid var(--gr5);
-  padding: 8px;
+  padding: 0;
   margin: 0 0 1em 0;
   border-radius: 6px;
+}
+
+[data-re-legend] {
+  margin: 0 0 0.5em 0;
 }
 
 [data-re-details] {
@@ -215,7 +219,7 @@
 
 [data-re-summary] {
   color: var(--gr2);
-  /* display: inline-block; */   /* hide the triangle */
+  /* display: inline-block; */ /* hide the triangle */
   padding: 2px;
   position: relative;
   /* border-bottom: 1px solid var(--gr5); */
@@ -274,17 +278,17 @@
   border-radius: 50%;
   padding: 0 2px;
   width: 1.4em;
-  height: 1.4em
+  height: 1.4em;
 }
 
 [data-re-regenerate-suffix-button]:hover {
-  background: var(--gr4);  
+  background: var(--gr4);
 }
 
 [data-re-regenerate-suffix-button]:active {
   position: relative;
   top: 1px;
-  left: 1px; 
+  left: 1px;
 }
 
 [data-re-pub-item] {
@@ -312,7 +316,8 @@
   display: inline-block;
 }
 
-[data-re-multiworkspace-settings-button], [data-re-back-button] {
+[data-re-multiworkspace-settings-button],
+[data-re-back-button] {
   color: var(--gr3);
   background: none;
   border: none;
@@ -321,13 +326,18 @@
   text-decoration-thickness: 2px;
 }
 
+[data-re-multiworkspace-settings-button]:hover,
+[data-re-back-button]:hover {
+  border: none;
+}
+
 [data-re-pub-item-remove-button] {
   color: var(--gr6);
   background: none;
   border: none;
   box-shadow: none;
   padding: 0;
-  margin-left: 0.5em
+  margin-left: 0.5em;
 }
 
 [data-re-pub-item-remove-button]:hover {
@@ -346,7 +356,7 @@
 [data-re-invitation-creator-pub-options] {
   margin: 1em 0 0 0;
 }
- 
+
 [data-re-dd] {
   margin: 0;
 }
@@ -364,18 +374,19 @@
   background-color: black;
 }
 
-
 [data-re-workspace-row] {
-  margin: 0 0 0.5em 0
+  margin: 0 0 0.5em 0;
 }
 
-[data-re-pubs-list-item], [data-re-pubeditor-list-item], [data-re-invitation-redemption-pub-list-item] {
+[data-re-pubs-list-item],
+[data-re-pubeditor-list-item],
+[data-re-invitation-redemption-pub-list-item] {
   display: inline-block;
   margin: 0 0.5em 0.5em 0;
 }
 
 [data-re-invitation-description] dd:first-of-type {
-  margin-bottom: 0.5em
+  margin-bottom: 0.5em;
 }
 
 [data-re-invitation-description] {

--- a/styles/junior.css
+++ b/styles/junior.css
@@ -1,21 +1,28 @@
 :root {
-  --gr6: #fffce7;
-  --gr5: #d1cabd;
-  --gr4: #a79c97;
-  --gr3: #837676;
-  --gr2: #64555a;
-  --gr1: #45333e;
+  --gr6: #f4eed4;
+  --gr5: #c8bfae;
+  --gr4: #a0948b;
+  --gr3: #7e706e;
+  --gr2: #615155;
+  --gr1: #44313b;
   --gr0: #220d1e;
-  --ac4: #6baa9f;
+  --ac4: #68a699;
   --ac3: #29857e;
   --ac2: #276060;
+
   --t1: 'Gill Sans', sans-serif;
   --sh: 1px 1px 0 1px rgba(0, 0, 0, 0.04);
   --sh2: 2px 2px 0 0 var(--gr5);
+  --sh3: 2px 2px 0 0 var(--gr4);
 }
 
 [data-re-earthbar] {
   font-family: var(--t1);
+}
+
+[data-re-earthbar-panel] code {
+  color: var(--ac2);
+  font-weight: bold;
 }
 
 [data-re-earthbar-tabs] {
@@ -101,7 +108,6 @@
   font-size: 1.5em;
   margin: 0 0 0.5em 0;
   color: var(--gr0);
-  text-decoration: underline;
   text-decoration-thickness: 2px;
   text-decoration-color: var(--gr4);
 }
@@ -135,6 +141,7 @@
 [data-re-button] {
   font-family: var(--t1);
   font-size: 1em;
+  font-weight: 600;
   border: 2px solid var(--gr3);
   padding: 6px;
   color: var(--gr0);
@@ -145,8 +152,8 @@
 }
 
 [data-re-button]:hover {
-  color: var(--gr0);
-  background: var(--gr6);
+  color: var(--ac2);
+  border: 2px solid var(--ac2);
 }
 
 [data-re-button]:active {
@@ -195,7 +202,7 @@
 }
 
 [data-re-fieldset] {
-  border: 1px solid var(--gr5);
+  border: 0px solid var(--gr5);
   padding: 8px;
   margin: 0 0 1em 0;
   border-radius: 6px;
@@ -208,15 +215,15 @@
 
 [data-re-summary] {
   color: var(--gr2);
-  display: inline-block;
+  /* display: inline-block; */   /* hide the triangle */
   padding: 2px;
   position: relative;
-  border-bottom: 1px solid var(--gr5);
+  /* border-bottom: 1px solid var(--gr5); */
 }
 
 [data-re-summary]:hover {
-  color: var(--ac2);
-  border-color: var(--ac4);
+  color: var(--ac3);
+  /* border-color: var(--ac4); */
 }
 
 [data-re-details-content] {
@@ -247,13 +254,19 @@
 }
 
 [data-re-workspace-name-input] {
+  margin-left: 6px;
   color: var(--gr6);
   background: var(--gr1);
   border: none;
+  width: 20ch;
+}
+
+[data-re-workspace-separator-dot] {
+  margin-left: 6px;
 }
 
 [data-re-regenerate-suffix-button] {
-  margin-left: 4px;
+  margin-left: 6px;
   color: var(--gr6);
   background: var(--gr3);
   border: 1px solid var(--gr4);
@@ -341,6 +354,16 @@
 [data-re-user-panel-save-identity-section] button {
   margin-right: 6px;
 }
+
+[data-re-user-panel-secret] code {
+  color: var(--gr4) !important;
+  background-color: var(--gr4) !important;
+}
+[data-re-user-panel-secret] code::selection {
+  color: white;
+  background-color: black;
+}
+
 
 [data-re-workspace-row] {
   margin: 0 0 0.5em 0

--- a/styles/layout.css
+++ b/styles/layout.css
@@ -20,6 +20,12 @@
   margin: 0;
 }
 
+[data-re-earthbar-panel] code {
+  font-size: 1.2em;
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
 /* A grid layout for a single text input with label and button*/
 
 [data-re-pubeditor-add-form],
@@ -240,6 +246,22 @@
 }
 
 
+/* UserPanel */
+
+[data-re-user-panel-address],
+[data-re-user-panel-secret] {
+  padding-left: 10px;
+}
+
+[data-re-user-panel-secret] code {
+  color: #888 !important;
+  background-color: #888 !important;
+}
+[data-re-user-panel-secret] code::selection {
+  color: white;
+  background-color: black;
+}
+
 /* ***** EARTHBAR ***** */
 
 /* Earthbar */
@@ -286,7 +308,7 @@
   align-items: baseline;
 }
 
-/* WorkspaceList*/
+/* WorkspaceList */
 
 [data-re-workspace-list-workspaces] {
   padding: 0;

--- a/styles/layout.css
+++ b/styles/layout.css
@@ -21,7 +21,6 @@
 }
 
 [data-re-earthbar-panel] code {
-  font-size: 1.2em;
   overflow-wrap: break-word;
   word-break: break-word;
 }
@@ -222,7 +221,7 @@
 }
 
 [data-re-workspace-creator-initial-pubs-fieldset] {
-  display: grid; 
+  display: grid;
   grid-template-areas: 'pubs pubs pubs pubs' 'pub-input pub-input pub-input pub-button';
   grid-template-columns: 1fr 1fr 1fr 1fr;
   grid-column-gap: 6px;
@@ -237,7 +236,7 @@
 }
 
 [data-re-workspace-creator-pub-add-button] {
-  grid-area: pub-button
+  grid-area: pub-button;
 }
 
 [data-re-pubs-list] {
@@ -245,18 +244,13 @@
   margin: 0;
 }
 
-
 /* UserPanel */
-
-[data-re-user-panel-address],
-[data-re-user-panel-secret] {
-  padding-left: 10px;
-}
 
 [data-re-user-panel-secret] code {
   color: #888 !important;
   background-color: #888 !important;
 }
+
 [data-re-user-panel-secret] code::selection {
   color: white;
   background-color: black;


### PR DESCRIPTION
Here's a bunch of little adjustments to the `standard-style` branch!  This is the first time I've made a PR to another PR so I'm not sure what will happen, it might need to be merged into the other PR before that one gets merged into `main`.

### Content changes

* Changed and added help text in many places, especially answering more questions about pubs
* Minor text changes to some headers and labels
* Change tab name "Settings" to "Workspace settings"
* Show a user's full address on the user page.  I think it's important for the user to be able to see it.  The secret is also shown using a "spoiler" style (select it to see it).  I didn't want to add the secret, but: I thought people would be confused if they only saw the address.  We talk about the secret in the help text but if it was never shown people might think that the public key part of the address was the secret, since it looks like random characters, so I thought I'd try showing everything so people understand all the moving parts.

### CSS and layout changes

* Regenerated the color theme with the lightest color now slightly darker to help with contrast against the white form inputs.
* Show disclosure triangles on `detail` elements and remove the underline.  (I could be convinced to leave this one alone.)
* Remove underline from `h1` since it's not a clickable thing
* Buttons turn green on hover to make sure they don't seem disabled
* Increase padding in new workspace widget
* Removed `fieldset` borders which felt cluttery and were only used in some places
* Whenever there are buttons for address/secret next to buttons for the keypair file, I added the word "or" between them.

---

New gr6 vs. white (from <a href="https://codesandbox.io/s/color-contrast-calculator-2-k0som?file=/src/App.tsx">updated CodeSandox preview</a>):

![Screen Shot 2021-01-27 at 4 26 35 PM](https://user-images.githubusercontent.com/32660718/106072132-7819b180-60bc-11eb-8ddd-68433b0cbddc.png)

---

Showing author address and secret:

![Screen Shot 2021-01-27 at 4 22 07 PM](https://user-images.githubusercontent.com/32660718/106072000-3426ac80-60bc-11eb-913b-18364e83ca05.png)

---

"Settings" --> "Workspace settings", and longer help text in the Danger Zone

![Screen Shot 2021-01-27 at 4 24 21 PM](https://user-images.githubusercontent.com/32660718/106072005-34bf4300-60bc-11eb-9139-0ba180c8b2aa.png)

---

(Side note: we could add a button in the Danger Zone called Delete All My Data, which replaces all your documents with empty strings.)