### PR TITLE
Prevent adding of pubs with no URL

### DIFF
--- a/src/components/PubEditor.tsx
+++ b/src/components/PubEditor.tsx
@@ -101,7 +101,12 @@ export default function PubEditor({
             </ComboboxPopover>
           ) : null}
         </Combobox>
-        <button data-re-pubeditor-add-button data-re-button type={'submit'}>
+        <button
+          data-re-pubeditor-add-button
+          data-re-button
+          type={'submit'}
+          disabled={pubToAdd.length === 0}
+        >
           {'Add pub'}
         </button>
       </form>

--- a/src/components/WorkspaceCreatorForm.tsx
+++ b/src/components/WorkspaceCreatorForm.tsx
@@ -162,6 +162,7 @@ export default function WorkspaceCreatorForm({
           <button
             data-re-button
             data-re-workspace-creator-pub-add-button
+            disabled={pubToAdd.length === 0}
             onClick={e => {
               e.preventDefault();
               setPubToAdd('');


### PR DESCRIPTION
Make it so that you cannot add pubs to workspaces when no value for the pub's URL is present.

Fixes #42

Punting on actual URL validation for the moment.