### PR TITLE
Better tab behaviour following certain actions

### DIFF
--- a/examples/earthbar/index.tsx
+++ b/examples/earthbar/index.tsx
@@ -125,12 +125,14 @@ function Examples() {
         </EarthbarExample>
       </EarthstarPeer>
       <hr />
-      <EarthbarExample title={'No workspaces'} />
-      <EarthbarExample title={'Multi, no workspaces'}>
-        <MultiWorkspaceTab />
-        <Spacer />
-        <AuthorTab />
-      </EarthbarExample>
+      <EarthstarPeer>
+        <EarthbarExample title={'No workspaces'} />
+        <EarthbarExample title={'Multi, no workspaces'}>
+          <MultiWorkspaceTab />
+          <Spacer />
+          <AuthorTab />
+        </EarthbarExample>
+      </EarthstarPeer>
     </>
   );
 }

--- a/src/components/InvitationRedemptionForm.tsx
+++ b/src/components/InvitationRedemptionForm.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { isErr } from 'earthstar';
 import Alert from '@reach/alert';
-import { useInvitation, useWorkspaces, usePubs } from '../hooks';
+import {
+  useInvitation,
+  useWorkspaces,
+  usePubs,
+  useCurrentWorkspace,
+} from '../hooks';
 import { WorkspaceLabel } from '../components';
 
 export default function InvitationRedemptionForm({
@@ -11,6 +16,7 @@ export default function InvitationRedemptionForm({
 }) {
   const workspaces = useWorkspaces();
   const [pubs] = usePubs();
+  const [, setCurrentWorkspace] = useCurrentWorkspace();
   const [code, setCode] = React.useState('');
   const result = useInvitation(code);
 
@@ -77,6 +83,7 @@ export default function InvitationRedemptionForm({
             }
             setCode('');
             setUncheckedPubs([]);
+            setCurrentWorkspace(workspace);
           }
         }}
       >

--- a/src/components/InvitationRedemptionForm.tsx
+++ b/src/components/InvitationRedemptionForm.tsx
@@ -8,6 +8,7 @@ import {
   useCurrentWorkspace,
 } from '../hooks';
 import { WorkspaceLabel } from '../components';
+import { EarthbarContext } from './earthbar';
 
 export default function InvitationRedemptionForm({
   onRedeem,
@@ -19,6 +20,7 @@ export default function InvitationRedemptionForm({
   const [, setCurrentWorkspace] = useCurrentWorkspace();
   const [code, setCode] = React.useState('');
   const result = useInvitation(code);
+  const { setActiveIndex, setFocusedIndex } = React.useContext(EarthbarContext);
 
   const [uncheckedPubs, setUncheckedPubs] = React.useState<string[]>([]);
 
@@ -84,6 +86,8 @@ export default function InvitationRedemptionForm({
             setCode('');
             setUncheckedPubs([]);
             setCurrentWorkspace(workspace);
+            setActiveIndex(-1);
+            setFocusedIndex(-1);
           }
         }}
       >

--- a/src/components/WorkspaceCreatorForm.tsx
+++ b/src/components/WorkspaceCreatorForm.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ValidatorEs4, isErr } from 'earthstar';
-import { useAddWorkspace, usePubs } from '../hooks';
+import { useAddWorkspace, useCurrentWorkspace, usePubs } from '../hooks';
 import { Alert } from '@reach/alert';
 import {
   Combobox,
@@ -43,6 +43,7 @@ export default function WorkspaceCreatorForm({
   const allPubs = Array.from(new Set(Object.values(pubs).flat()));
   const [addedPubs, setAddedPubs] = React.useState<string[]>([]);
   const selectablePubs = allPubs.filter(pubUrl => !addedPubs.includes(pubUrl));
+  const [, setCurrentWorkspace] = useCurrentWorkspace();
 
   const [pubToAdd, setPubToAdd] = React.useState('');
 
@@ -68,6 +69,8 @@ export default function WorkspaceCreatorForm({
           if (onCreate) {
             onCreate(address);
           }
+
+          setCurrentWorkspace(address);
         }}
       >
         <fieldset data-re-fieldset>

--- a/src/components/WorkspaceCreatorForm.tsx
+++ b/src/components/WorkspaceCreatorForm.tsx
@@ -9,6 +9,7 @@ import {
   ComboboxList,
   ComboboxOption,
 } from '@reach/combobox';
+import { EarthbarContext } from './earthbar/Earthbar';
 
 const LETTERS = 'abcdefghijklmnopqrstuvwxyz';
 const NUMBERS = '1234567890';
@@ -33,6 +34,8 @@ export default function WorkspaceCreatorForm({
 }) {
   const [pubs, setPubs] = usePubs();
   const add = useAddWorkspace();
+
+  const { setActiveIndex, setFocusedIndex } = React.useContext(EarthbarContext);
 
   const [workspaceName, setWorkspaceName] = React.useState('');
   const [workspaceSuffix, setWorkspaceSuffix] = React.useState(generateSuffix);
@@ -71,6 +74,8 @@ export default function WorkspaceCreatorForm({
           }
 
           setCurrentWorkspace(address);
+          setFocusedIndex(-1);
+          setActiveIndex(-1);
         }}
       >
         <fieldset data-re-fieldset>

--- a/src/components/earthbar/WorkspaceManagerPanel.tsx
+++ b/src/components/earthbar/WorkspaceManagerPanel.tsx
@@ -1,11 +1,18 @@
 import React from 'react';
-import { EarthbarTabPanel } from './Earthbar';
+import { EarthbarContext, EarthbarTabPanel } from './Earthbar';
 import { WorkspaceOptions } from './WorkspaceOptions';
 
 export default function WorkspaceManagerPanel() {
+  const { setActiveIndex, setFocusedIndex } = React.useContext(EarthbarContext);
+
   return (
     <EarthbarTabPanel data-re-workspace-manager-panel>
-      <WorkspaceOptions />
+      <WorkspaceOptions
+        onRemove={() => {
+          setActiveIndex(-1);
+          setFocusedIndex(-1);
+        }}
+      />
     </EarthbarTabPanel>
   );
 }

--- a/src/components/earthbar/WorkspaceTab.tsx
+++ b/src/components/earthbar/WorkspaceTab.tsx
@@ -8,6 +8,7 @@ import {
 import { useCurrentWorkspace } from '../../index';
 import { EarthbarTabLabel, EarthbarTab, EarthbarTabPanel } from './Earthbar';
 import { getWorkspaceName } from '../../util';
+import { usePrevious } from '@reach/utils';
 
 export default function WorkspaceTab() {
   const [currentWorkspace, setCurrentWorkspace] = useCurrentWorkspace();
@@ -15,6 +16,15 @@ export default function WorkspaceTab() {
     currentWorkspace || 'ADD_WORKSPACE'
   );
   const workspaces = useWorkspaces();
+
+  const previousWorkspace = usePrevious(currentWorkspace);
+
+  // This effect will change the selected option to match the current workspace when it changes
+  React.useEffect(() => {
+    if (currentWorkspace && previousWorkspace !== currentWorkspace) {
+      setSelectedOption(currentWorkspace);
+    }
+  }, [currentWorkspace, previousWorkspace]);
 
   return (
     <div data-re-earthbar-workspace-tab-zone>


### PR DESCRIPTION
This PR makes it so that all tabs close following these actions:

- A workspace is joined
- A workspace is created
- A workspace is deleted

And also makes it so that when a workspace is joined or created it immediately becomes the current workspace.