### PR TITLE
Add better layouts for skinny sizes

### DIFF
--- a/src/components/InvitationCreatorForm.tsx
+++ b/src/components/InvitationCreatorForm.tsx
@@ -19,7 +19,7 @@ export default function InvitationCreatorForm({
   }, [copied]);
 
   return (
-    <>
+    <div data-re-invitation-creator-form>
       {pubs.length > 0 ? (
         <dl data-re-invitation-creator-pub-options>
           <dt data-re-dt>{'Included pubs'}</dt>
@@ -55,15 +55,13 @@ export default function InvitationCreatorForm({
           </dd>
         </dl>
       ) : null}
-      <div data-re-invitation-creator-form>
-        <input
-          data-re-invitation-creator-input
-          data-re-input
-          value={invitationCode}
-          disabled={true}
-        />
-        <CopyButton copyValue={invitationCode} />
-      </div>
-    </>
+      <input
+        data-re-invitation-creator-input
+        data-re-input
+        value={invitationCode}
+        disabled={true}
+      />
+      <CopyButton copyValue={invitationCode} />
+    </div>
   );
 }

--- a/styles/junior.css
+++ b/styles/junior.css
@@ -257,6 +257,12 @@
   font-variant-numeric: tabular-nums;
 }
 
+@media screen and (max-width: 600px) {
+  [data-re-workspace-address-fields] {
+    font-size: 1em;
+  }
+}
+
 [data-re-workspace-name-input] {
   margin-left: 6px;
   color: var(--gr6);

--- a/styles/layout.css
+++ b/styles/layout.css
@@ -36,6 +36,17 @@
   grid-column-gap: 6px;
 }
 
+@media screen and (max-width: 600px) {
+  [data-re-pubeditor-add-form],
+  [data-re-keypair-form],
+  [data-re-display-name-form] {
+    display: grid;
+    grid-template-areas: 'label ' 'input' 'button';
+    grid-template-columns: 1fr;
+    grid-row-gap: 6px;
+  }
+}
+
 /* ***** COMPONENTS ***** */
 
 /* AddWorkspaceForm */
@@ -73,6 +84,15 @@
   grid-template-areas: 'address-label secret-label .' 'address-input secret-input button';
   grid-template-columns: 1.5fr 1.5fr 1fr;
   grid-column-gap: 6px;
+}
+
+@media screen and (max-width: 600px) {
+  [data-re-author-keypair-form] {
+    display: grid;
+    grid-template-areas: 'address-label ' 'address-input' 'secret-label' 'secret-input' 'button';
+    grid-template-columns: 1fr;
+    grid-row-gap: 4px;
+  }
 }
 
 [data-re-author-form-address-label] {
@@ -126,9 +146,18 @@
 
 [data-re-invitation-creator-form] {
   display: grid;
-  grid-template-areas: 'input input input button' 'pub-options pub-options pub-options pub-options';
+  grid-template-areas: 'pub-options pub-options pub-options pub-options' 'input input input button';
   grid-template-columns: 1fr 1fr 1fr 1fr;
   grid-column-gap: 6px;
+}
+
+@media screen and (max-width: 600px) {
+  [data-re-invitation-creator-form] {
+    display: grid;
+    grid-template-areas: 'pub-options' 'input' 'button';
+    grid-template-columns: 1fr;
+    grid-row-gap: 6px;
+  }
 }
 
 [data-re-invitation-creator-input] {
@@ -225,6 +254,15 @@
   grid-template-areas: 'pubs pubs pubs pubs' 'pub-input pub-input pub-input pub-button';
   grid-template-columns: 1fr 1fr 1fr 1fr;
   grid-column-gap: 6px;
+}
+
+@media screen and (max-width: 600px) {
+  [data-re-workspace-creator-initial-pubs-fieldset] {
+    display: grid;
+    grid-template-areas: 'pubs' 'pub-input' 'pub-button';
+    grid-template-columns: 1fr;
+    grid-row-gap: 6px;
+  }
 }
 
 [data-re-pubs-list] {


### PR DESCRIPTION
This adds media queries that change layouts based on screen size rather than the size of the earthbar itself, so it's not perfect, but it'll do for now.

<img width="460" alt="image" src="https://user-images.githubusercontent.com/579491/106471627-1e412f00-64a2-11eb-95d3-b68373eff8d6.png">

<img width="464" alt="image" src="https://user-images.githubusercontent.com/579491/106471645-2305e300-64a2-11eb-99a9-20675812a180.png">
