### PR TITLE
Pass workspace address to RemoveWorkspaceButton in WorkspaceOptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "tsdx lint",
     "prepare": "tsdx build",
     "components-example": "parcel examples/components/index.html",
-    "earthbar-example": "parcel examples/earthbar/index.html --port 2345"
+    "earthbar-example": "parcel examples/earthbar/index.html"
   },
   "peerDependencies": {
     "earthstar": "^5.7.4",

--- a/src/components/RemoveWorkspaceButton.tsx
+++ b/src/components/RemoveWorkspaceButton.tsx
@@ -33,8 +33,9 @@ export default function RemoveWorkspaceButton({
           remove(address);
         }
       }}
+      disabled={!address}
     >
-      {children || `Remove ${address}`}
+      {children || address ? `Remove ${address}` : "Can't remove"}
     </button>
   );
 }

--- a/src/components/earthbar/WorkspaceOptions.tsx
+++ b/src/components/earthbar/WorkspaceOptions.tsx
@@ -45,7 +45,10 @@ export function WorkspaceOptions({
           make sure to give your deletions time to sync with the pubs before you
           remove the entire workspace.
         </p>
-        <RemoveWorkspaceButton onClick={onRemove} />
+        <RemoveWorkspaceButton
+          workspaceAddress={workspaceAddress}
+          onClick={onRemove}
+        />
       </section>
     </div>
   );


### PR DESCRIPTION
Two little tweaks:

- Pass down the selected Workspace's address in WorkspaceOption, which should fix a "Remove null" button in MultiWorkspaceTab
- Use the same port for the component and earthbar examples as I rarely need to see them at the same time, and it's kind of annoying for my dev setup