### PR TITLE
Add some new guidances to Earthbar, tidy them up a bit

### DIFF
--- a/src/components/InvitationRedemptionForm.tsx
+++ b/src/components/InvitationRedemptionForm.tsx
@@ -8,6 +8,11 @@ import {
   useCurrentWorkspace,
 } from '../hooks';
 import WorkspaceLabel from '../components/WorkspaceLabel';
+import {
+  WhatIsAPub,
+  WhatIsAWorkspace,
+  WhereToGetInvitationCode,
+} from './guidance/guidances';
 
 export default function InvitationRedemptionForm({
   onRedeem,
@@ -111,7 +116,7 @@ export default function InvitationRedemptionForm({
                   ? ' (already added)'
                   : null}
               </dd>
-              <dt data-re-dt>{'Pubs'}</dt>
+              <dt data-re-dt>{'Pub servers'}</dt>
               <dd data-re-dd>
                 {result.pubs.length > 0
                   ? result.pubs.map(pubUrl => (
@@ -170,17 +175,9 @@ export default function InvitationRedemptionForm({
           </button>
         ) : null}
       </form>
-      <details data-re-details key={'help-where-to-get'}>
-        <summary data-re-summary>
-          {'Where can I get an invitation code?'}
-        </summary>
-        <div data-re-details-content>
-          <p>
-            Ask an existing member to make an invitation code from the workspace
-            settings page.
-          </p>
-        </div>
-      </details>
+      <WhatIsAWorkspace />
+      <WhereToGetInvitationCode />
+      <WhatIsAPub />
     </>
   );
 }

--- a/src/components/WorkspaceCreatorForm.tsx
+++ b/src/components/WorkspaceCreatorForm.tsx
@@ -9,6 +9,13 @@ import {
   ComboboxList,
   ComboboxOption,
 } from '@reach/combobox';
+import {
+  WhatIsAPub,
+  WhatIsAWorkspace,
+  WhatWillCreateWorkspaceFormDo,
+  WhereToFindPubServers,
+  WhoCanJoinMyWorkspace,
+} from './guidance/guidances';
 
 const LETTERS = 'abcdefghijklmnopqrstuvwxyz';
 const NUMBERS = '1234567890';
@@ -178,65 +185,11 @@ export default function WorkspaceCreatorForm({
           </button>
         ) : null}
       </form>
-      <details data-re-details>
-        <summary data-re-summary>{'What will this form do?'}</summary>
-        <div data-re-details-content>
-          <p>
-            A new workspace will be made on your device, and it will be synced
-            with the pub servers given above. If you don't add any pub servers,
-            your data will only exist on your own device. You can add pub
-            servers later.
-          </p>
-        </div>
-      </details>
-      <details data-re-details>
-        <summary data-re-summary>{'What are pub servers?'}</summary>
-        <div data-re-details-content>
-          <p>
-            Pub servers run in the cloud and hold a copy of the workspace data.
-            They help keep the data online so it can sync even when some
-            people's devices are turned off.
-          </p>
-          <p>
-            One workspace can use several pub servers; each will hold a complete
-            redundant copy of the data. You can add more pubs whenever you like.
-          </p>
-        </div>
-      </details>
-      <details data-re-details>
-        <summary data-re-summary>{'Where do I find pub servers?'}</summary>
-        <div data-re-details-content>
-          <p>
-            Ask your friends, or run your own using{' '}
-            <a href="https://github.com/earthstar-project/earthstar-pub#running-on-glitch">
-              these instructions.
-            </a>
-          </p>
-          <p>
-            Pub servers can see your data, so it's best to use ones run by
-            people you know and trust.
-          </p>
-        </div>
-      </details>
-      <details data-re-details>
-        <summary data-re-summary>
-          {'Who will be able to join my workspace?'}
-        </summary>
-        <div data-re-details-content>
-          <p>
-            Anyone who knows a workspace address, and at least one of its pubs,
-            can join it. They will be able to read and write data.
-          </p>
-          <p>
-            After creating your workspace, you can get an invitation code to
-            send to your friends from the workspace settings page.
-          </p>
-          <p>
-            Your workspace can also be joined by whoever is running the pubs it
-            syncs with.
-          </p>
-        </div>
-      </details>
+      <WhatIsAWorkspace />
+      <WhatWillCreateWorkspaceFormDo />
+      <WhatIsAPub />
+      <WhereToFindPubServers />
+      <WhoCanJoinMyWorkspace />
     </>
   );
 }

--- a/src/components/earthbar/MultiWorkspaceManagerPanel.tsx
+++ b/src/components/earthbar/MultiWorkspaceManagerPanel.tsx
@@ -7,6 +7,7 @@ import { useWorkspaces } from '../../hooks';
 import { WorkspaceOptions } from './WorkspaceOptions';
 import { EarthbarContext } from './contexts';
 import EarthbarTabPanel from './EarthbarTabPanel';
+import { WhatIsAWorkspace } from '../guidance/guidances';
 
 type WorkspaceManagerState =
   | { screen: 'list' }
@@ -90,6 +91,7 @@ function WorkspaceList({
             </p>
           </>
         )}
+        <WhatIsAWorkspace />
       </section>
     </div>
   );

--- a/src/components/earthbar/NewUserPanel.tsx
+++ b/src/components/earthbar/NewUserPanel.tsx
@@ -3,6 +3,11 @@ import EarthbarTabPanel from './EarthbarTabPanel';
 import AuthorKeypairForm from '../AuthorKeypairForm';
 import AuthorKeypairUpload from '../AuthorKeypairUpload';
 import NewKeypairForm from '../NewKeypairForm';
+import {
+  CanIChangeMyNickname,
+  CanIResetMySecret,
+  WhatIsAnAuthorIdentity,
+} from '../guidance/guidances';
 
 export default function NewUserPanel() {
   return (
@@ -15,35 +20,8 @@ export default function NewUserPanel() {
         <p>
           And be sure to <b>save your new identity on the next screen!</b>
         </p>
-        <details data-re-details>
-          <summary data-re-summary>{'What is an author identity?'}</summary>
-          <div data-re-details-content>
-            <p>
-              {
-                "It's like a user account. You can write data to workspaces with it."
-              }
-            </p>
-            <p>
-              It has a public <b>address</b> made of a 4 letter nickname plus a
-              cryptographic public key, and a cryptographic <b>secret</b> that's
-              similar to a password.
-            </p>
-            <p>
-              {
-                'You can have many identities, or use a single one across many workspaces.'
-              }
-            </p>
-          </div>
-        </details>
-        <details data-re-details>
-          <summary data-re-summary>{'Can I change my nickname later?'}</summary>
-          <div data-re-details-content>
-            <p>
-              No, but after you sign in you can set a <b>display name</b> which
-              you can change whenever you like.
-            </p>
-          </div>
-        </details>
+        <WhatIsAnAuthorIdentity />
+        <CanIChangeMyNickname />
       </section>
       <hr />
       <section data-re-new-user-panel-login-section>
@@ -51,23 +29,7 @@ export default function NewUserPanel() {
         <AuthorKeypairForm />
         <hr />
         <AuthorKeypairUpload />
-        <details data-re-details>
-          <summary data-re-summary>
-            {'I lost my secret, can I reset it?'}
-          </summary>
-          <div data-re-details-content>
-            <p>
-              {
-                'Unfortunately not! Your public address and secret are tied together, and neither can be changed after creation.'
-              }
-            </p>
-            <p>
-              {
-                "If you've lost your secret, the best thing to to do is create a new identity and tell your friends about it."
-              }
-            </p>
-          </div>
-        </details>
+        <CanIResetMySecret />
       </section>
     </EarthbarTabPanel>
   );

--- a/src/components/earthbar/UserPanel.tsx
+++ b/src/components/earthbar/UserPanel.tsx
@@ -8,6 +8,11 @@ import {
   SignOutButton,
 } from '../';
 import { useCurrentAuthor, useCurrentWorkspace } from '../../hooks';
+import {
+  CanITellMyIdentity,
+  HowDoIdentitiesWork,
+  WhyDoINeedToSaveMyIdentity,
+} from '../guidance/guidances';
 
 export default function UserPanel() {
   const [currentWorkspace] = useCurrentWorkspace();
@@ -43,76 +48,9 @@ export default function UserPanel() {
         <hr />
         Or <DownloadKeypairButton /> containing your address and secret.
         <hr />
-        <details data-re-details>
-          <summary data-re-summary>
-            {'Why do I need to save my identity?'}
-          </summary>
-          <div data-re-details-content>
-            <p>
-              {
-                'Your identity is not stored on any servers, so if you lose access to it there is no way to retrieve it.'
-              }
-            </p>
-            <p>
-              {'Should this happen, you will need to generate a new identity.'}
-            </p>
-            <p>
-              {
-                'We recommend storing your author address and secret, or keypair.json, in a password manager.'
-              }
-            </p>
-          </div>
-        </details>
-        <details data-re-details>
-          <summary data-re-summary>
-            {'Can I tell other people my identity?'}
-          </summary>
-          <div data-re-details-content>
-            <p>
-              It's safe to tell friends your author <b>address</b> -- the whole
-              long thing.
-            </p>
-            <p>
-              Since anyone can make an address with the same nickname as you,
-              telling people your entire address will help them know they're not
-              talking to an impostor.
-            </p>
-            <p>
-              Don't share your <b>secret</b> -- treat it like a password.
-            </p>
-          </div>
-        </details>
-        <details data-re-details>
-          <summary data-re-summary>
-            {'How does this work under the hood?'}
-          </summary>
-          <div data-re-details-content>
-            <p>
-              Your address is a cryptographic public key, and your secret is the
-              corresponding private key.
-            </p>
-            <p>
-              Your data is signed, but not encrypted, with this keypair. Anyone
-              can in the workspace can read it, but nobody can alter it or the
-              signature would become invalid.
-            </p>
-            <p>
-              Earthstar uses{' '}
-              <a href="https://github.com/earthstar-project/earthstar/blob/master/docs/specification.md#ed25519-signatures">
-                ed25519 keypairs encoded in base32.
-              </a>
-            </p>
-            <p>
-              The 4-character nickname is not part of the keypair but is
-              considered part of your distinct identity. You can make multiple
-              identities with the same keypair and different nicknames and they
-              will be considered different identities. Here's more about{' '}
-              <a href="https://github.com/earthstar-project/earthstar/blob/master/docs/specification.md#faq-author-shortnames">
-                the reasoning behind this design.
-              </a>
-            </p>
-          </div>
-        </details>
+        <WhyDoINeedToSaveMyIdentity />
+        <CanITellMyIdentity />
+        <HowDoIdentitiesWork />
       </section>
       <hr />
       <section data-re-user-panel-sign-out-section>

--- a/src/components/earthbar/WorkspaceOptions.tsx
+++ b/src/components/earthbar/WorkspaceOptions.tsx
@@ -5,6 +5,7 @@ import {
   InvitationCreatorForm,
   SyncingCheckbox,
 } from '..';
+import { WhatIsAPub } from '../guidance/guidances';
 
 export function WorkspaceOptions({
   workspaceAddress,
@@ -21,8 +22,8 @@ export function WorkspaceOptions({
       <hr />
       <section data-re-section>
         <h1>{'Pub Servers'}</h1>
-        <p>{'Servers that help this workspace sync its data.'}</p>
         <PubEditor workspaceAddress={workspaceAddress} />
+        <WhatIsAPub />
       </section>
       <hr />
       <section data-re-section>

--- a/src/components/guidance/_Guidance.tsx
+++ b/src/components/guidance/_Guidance.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+
+export default function Guidance({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <details data-re-details>
+      <summary data-re-summary>{title}</summary>
+      <div data-re-details-content>{children}</div>
+    </details>
+  );
+}

--- a/src/components/guidance/guidances.tsx
+++ b/src/components/guidance/guidances.tsx
@@ -138,7 +138,11 @@ export function WhatIsAWorkspace() {
           'You can join or create as many workspaces as you want. A single workspace can be used by many different apps.'
         }
       </p>
-      <p>{"Workspaces' data are stored on pub servers."}</p>
+      <p>
+        {
+          "Workspaces' data are stored on pub servers and in your browser's storage on your own computer."
+        }
+      </p>
     </Guidance>
   );
 }

--- a/src/components/guidance/guidances.tsx
+++ b/src/components/guidance/guidances.tsx
@@ -1,0 +1,225 @@
+import * as React from 'react';
+import Guidance from './_Guidance';
+
+export function CanITellMyIdentity() {
+  return (
+    <Guidance title={'Can I tell other people my identity?'}>
+      <p>
+        {
+          "It's safe to tell friends your author <b>address</b> -- the whole long thing."
+        }
+      </p>
+      <p>
+        {
+          "Since anyone can make an address with the same nickname as you, telling people your entire address will help them know they're not talking to an impostor."
+        }
+      </p>
+      <p>
+        {"Don't share your "}
+        <b>{'secret'}</b>
+        {' — treat it like a password.'}
+      </p>
+    </Guidance>
+  );
+}
+
+export function HowDoIdentitiesWork() {
+  return (
+    <Guidance title={'How do identities work under the hood?'}>
+      <p>
+        {
+          'Your address is a cryptographic public key, and your secret is the corresponding private key.'
+        }
+      </p>
+      <p>
+        {
+          'Your data is signed, but not encrypted, with this keypair. Anyone can in the workspace can read it, but nobody can alter it or the signature would become invalid.'
+        }
+      </p>
+      <p>
+        {'Earthstar uses '}
+        <a href="https://github.com/earthstar-project/earthstar/blob/master/docs/specification.md#ed25519-signatures">
+          {'ed25519 keypairs encoded in base32.'}
+        </a>
+      </p>
+      <p>
+        {
+          "The 4-character nickname is not part of the keypair but is considered part of your distinct identity. You can make multiple identities with the same keypair and different nicknames and they will be considered different identities. Here's more about "
+        }
+        <a href="https://github.com/earthstar-project/earthstar/blob/master/docs/specification.md#faq-author-shortnames">
+          {'the reasoning behind this design.'}
+        </a>
+      </p>
+    </Guidance>
+  );
+}
+
+export function CanIChangeMyNickname() {
+  return (
+    <Guidance title={'Can I change my nickname later?'}>
+      {' '}
+      <p>
+        {'No, but after you sign in you can set a '}
+        <b>{'display name'}</b>
+        {' which you can change whenever you like.'}
+      </p>
+    </Guidance>
+  );
+}
+
+export function CanIResetMySecret() {
+  return (
+    <Guidance title={'I lost my secret, can I reset it?'}>
+      <p>
+        {
+          'Unfortunately not! Your public address and secret are tied together, and neither can be changed after creation.'
+        }
+      </p>
+      <p>
+        {
+          "If you've lost your secret, the best thing to to do is create a new identity and tell your friends about it."
+        }
+      </p>
+    </Guidance>
+  );
+}
+
+export function WhatIsAnAuthorIdentity() {
+  return (
+    <Guidance title={'What is an author identity?'}>
+      <p>
+        {"It's like a user account. You can write data to workspaces with it."}
+      </p>
+      <p>
+        {'It has a public '}
+        <b>{'address'}</b>
+        {
+          ' made of a 4 letter nickname plus a cryptographic public key, and a cryptographic '
+        }
+        <b>{'secret'}</b>
+        {" that's similar to a password."}
+      </p>
+      <p>
+        {
+          'You can have many identities, or use a single one across many workspaces.'
+        }
+      </p>
+    </Guidance>
+  );
+}
+
+export function WhatIsAPub() {
+  return (
+    <Guidance title={'What are pub servers?'}>
+      <p>
+        {
+          "Pub servers run in the cloud and hold a copy of the workspace data. They help keep the data online so it can sync even when some people's devices are turned off."
+        }
+      </p>
+      <p>
+        {
+          'One workspace can use several pub servers; each will hold a complete redundant copy of the data. You can add more pubs whenever you like.'
+        }
+      </p>
+    </Guidance>
+  );
+}
+
+export function WhatIsAWorkspace() {
+  return (
+    <Guidance title={'What is a workspace?'}>
+      <p>
+        {
+          'Think of a workspace as a shareable folder. It has an address (e.g. +cooking.z95uf), and whoever knows the address can read and write data in that folder.'
+        }
+      </p>
+      <p>
+        {
+          'You can join or create as many workspaces as you want. A single workspace can be used by many different apps.'
+        }
+      </p>
+      <p>{"Workspaces' data are stored on pub servers."}</p>
+    </Guidance>
+  );
+}
+
+export function WhatWillCreateWorkspaceFormDo() {
+  return (
+    <Guidance title={'What will this form do?'}>
+      <p>
+        {
+          "  A new workspace will be made on your device, and it will be synced with the pub servers given above. If you don't add any pub servers, your data will only exist on your own device. You can add pub servers later."
+        }
+      </p>
+    </Guidance>
+  );
+}
+
+export function WhereToFindPubServers() {
+  return (
+    <Guidance title={'Where do I find pub servers?'}>
+      <p>
+        {'Ask your friends, or run your own using '}
+        <a href="https://github.com/earthstar-project/earthstar-pub#running-on-glitch">
+          {'these instructions.'}
+        </a>
+      </p>
+      <p>
+        {
+          "Pub servers can see your data, so it's best to use ones run by people you know and trust."
+        }
+      </p>
+    </Guidance>
+  );
+}
+
+export function WhereToGetInvitationCode() {
+  return (
+    <Guidance title={'Where can I get an invitation code?'}>
+      <p>
+        Ask an existing member to make an invitation code from the workspace
+        settings page.
+      </p>
+    </Guidance>
+  );
+}
+
+export function WhoCanJoinMyWorkspace() {
+  return (
+    <Guidance title={'Who will be able to join my workspace?'}>
+      <p>
+        {
+          'Anyone who knows a workspace address, and at least one of its pubs, can join it. They will be able to read and write data.'
+        }
+      </p>
+      <p>
+        {
+          ' After creating your workspace, you can get an invitation code to send to your friends from the workspace settings page.'
+        }
+      </p>
+      <p>
+        {
+          'Your workspace can also be joined by whoever is running the pubs it syncs with.'
+        }
+      </p>
+    </Guidance>
+  );
+}
+
+export function WhyDoINeedToSaveMyIdentity() {
+  return (
+    <Guidance title={"'Why do I need to save my identity?'"}>
+      <p>
+        {
+          'Your identity is not stored on any servers, so if you lose access to it there is no way to retrieve it.'
+        }
+      </p>
+      <p>{'Should this happen, you will need to generate a new identity.'}</p>
+      <p>
+        {
+          'We recommend storing your author address and secret, or keypair.json, in a password manager.'
+        }
+      </p>
+    </Guidance>
+  );
+}

--- a/styles/layout.css
+++ b/styles/layout.css
@@ -219,6 +219,7 @@
 
 [data-re-pubeditor-list] {
   padding: 0;
+  margin: 0;
   list-style: none;
 }
 


### PR DESCRIPTION
This PR:

- Adds a private Guidance component to expedite making those helper text things a bit
- Moves all the current guidances into a single file, which makes other components a bit easier to digest
- Adds a few new guidances, especially for the join panel which had none and was often the first point of contact for a new user