### PR TITLE
Adjust default layout for Earthbar tabs to better align tabs

### DIFF
--- a/styles/layout.css
+++ b/styles/layout.css
@@ -305,7 +305,7 @@
 
 [data-re-earthbar-tabs] {
   display: flex;
-  align-content: flex-end;
+  align-items: baseline;
 }
 
 /* EarthbarTabLabel */


### PR DESCRIPTION
Saw that tabs were aligning a bit wonky on the vertical axis, I've adjusted the default layout so that they align on the text baseline.