### PR TITLE
Upgrade to earthstar v6, use Asynchronous StorageLocalStorage

### DIFF
--- a/examples/earthbar/index.tsx
+++ b/examples/earthbar/index.tsx
@@ -103,7 +103,8 @@ function Examples() {
       >
         <hr />
         <EarthbarExample title={'Default Earthbar'}></EarthbarExample>
-
+      </EarthstarPeer>
+      <EarthstarPeer initIsLive={false}>
         <EarthbarExample title={'Earthbar for all-workspaces-at-once app'}>
           <MultiWorkspaceTab />
           <Spacer />
@@ -120,7 +121,8 @@ function Examples() {
         <EarthbarExample
           title={'Default Earthbar (signed in)'}
         ></EarthbarExample>
-
+      </EarthstarPeer>
+      <EarthstarPeer initIsLive={false}>
         <EarthbarExample
           title={'Earthbar for all-workspaces-at-once app (signed in)'}
         >
@@ -132,6 +134,8 @@ function Examples() {
       <hr />
       <EarthstarPeer initIsLive={false}>
         <EarthbarExample title={'No workspaces'} />
+      </EarthstarPeer>
+      <EarthstarPeer initIsLive={false}>
         <EarthbarExample title={'Multi, no workspaces'}>
           <MultiWorkspaceTab />
           <Spacer />
@@ -141,6 +145,9 @@ function Examples() {
       <hr />
       <EarthstarPeer {...initValues} initIsLive={false}>
         <EarthbarExample title={'From localstorage'} />
+        <LocalStorageSettingsWriter storageKey={'example'} />
+      </EarthstarPeer>
+      <EarthstarPeer {...initValues} initIsLive={false}>
         <EarthbarExample title={'Multi, from localstorage'}>
           <MultiWorkspaceTab />
           <Spacer />

--- a/examples/earthbar/index.tsx
+++ b/examples/earthbar/index.tsx
@@ -5,6 +5,7 @@ import {
   ValidatorEs4,
   generateAuthorKeypair,
   AuthorKeypair,
+  StorageToAsync,
 } from 'earthstar';
 import {
   EarthstarPeer,
@@ -81,6 +82,14 @@ function EarthbarExample({
   );
 }
 
+function makeStorages() {
+  return [
+    EXAMPLE_WORKSPACE_ADDR1,
+    EXAMPLE_WORKSPACE_ADDR2,
+    EXAMPLE_WORKSPACE_ADDR3,
+  ].map(addr => new StorageToAsync(new StorageMemory([ValidatorEs4], addr), 0));
+}
+
 function Examples() {
   const initValues = useLocalStorageEarthstarSettings('example');
 
@@ -88,11 +97,7 @@ function Examples() {
     <>
       <h1>react-earthstar earthbar</h1>
       <EarthstarPeer
-        initWorkspaces={[
-          new StorageMemory([ValidatorEs4], EXAMPLE_WORKSPACE_ADDR1),
-          new StorageMemory([ValidatorEs4], EXAMPLE_WORKSPACE_ADDR2),
-          new StorageMemory([ValidatorEs4], EXAMPLE_WORKSPACE_ADDR3),
-        ]}
+        initWorkspaces={makeStorages()}
         initPubs={pubs}
         initIsLive={false}
       >
@@ -107,11 +112,7 @@ function Examples() {
       </EarthstarPeer>
       <hr />
       <EarthstarPeer
-        initWorkspaces={[
-          new StorageMemory([ValidatorEs4], EXAMPLE_WORKSPACE_ADDR1),
-          new StorageMemory([ValidatorEs4], EXAMPLE_WORKSPACE_ADDR2),
-          new StorageMemory([ValidatorEs4], EXAMPLE_WORKSPACE_ADDR3),
-        ]}
+        initWorkspaces={makeStorages()}
         initPubs={pubs}
         initIsLive={false}
         initCurrentAuthor={EXAMPLE_USER}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "earthbar-example": "parcel examples/earthbar/index.html"
   },
   "peerDependencies": {
-    "earthstar": "^5.7.6",
+    "earthstar": "^6.3.1",
     "react": "~16.13.1"
   },
   "husky": {
@@ -44,7 +44,7 @@
     "@types/jest": "^26.0.14",
     "@types/react-dom": "^16.9.8",
     "babel-jest": "^26.5.2",
-    "earthstar": "^6.1.0",
+    "earthstar": "^6.3.1",
     "eslint-plugin-react-hooks": "^4.1.2",
     "husky": "^4.3.0",
     "jest-localstorage-mock": "^2.4.6",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/jest": "^26.0.14",
     "@types/react-dom": "^16.9.8",
     "babel-jest": "^26.5.2",
-    "earthstar": "^5.7.6",
+    "earthstar": "^6.1.0",
     "eslint-plugin-react-hooks": "^4.1.2",
     "husky": "^4.3.0",
     "jest-localstorage-mock": "^2.4.6",

--- a/src/components/DeleteMyDataForm.tsx
+++ b/src/components/DeleteMyDataForm.tsx
@@ -1,5 +1,5 @@
-// import { deleteMyDocuments } from 'earthstar';
 import * as React from 'react';
+import { deleteMyDocumentsAsync } from 'earthstar';
 import { useCurrentAuthor, useStorage } from '../hooks';
 import WorkspaceLabel from './WorkspaceLabel';
 
@@ -43,7 +43,7 @@ export default function DeleteMyDataForm(props: { workspaceAddress: string }) {
         {...props}
         data-re-button
         data-re-delete-my-data-button
-        onClick={() => {
+        onClick={async () => {
           if (!storage || !currentAuthor) {
             return;
           }
@@ -56,10 +56,12 @@ export default function DeleteMyDataForm(props: { workspaceAddress: string }) {
             return;
           }
 
-          // TODO: No deleteMyDocuments for IStorageAsync yet
-          //const { numDeleted } = deleteMyDocuments(storage, currentAuthor);
+          const { numDeleted } = await deleteMyDocumentsAsync(
+            storage,
+            currentAuthor
+          );
 
-          setNumberDeleted(/* numDeleted */ 0);
+          setNumberDeleted(numDeleted);
           setDeleted(true);
           setPrompt('');
         }}

--- a/src/components/DeleteMyDataForm.tsx
+++ b/src/components/DeleteMyDataForm.tsx
@@ -1,4 +1,4 @@
-import { deleteMyDocuments } from 'earthstar';
+// import { deleteMyDocuments } from 'earthstar';
 import * as React from 'react';
 import { useCurrentAuthor, useStorage } from '../hooks';
 import WorkspaceLabel from './WorkspaceLabel';
@@ -56,9 +56,10 @@ export default function DeleteMyDataForm(props: { workspaceAddress: string }) {
             return;
           }
 
-          const { numDeleted } = deleteMyDocuments(storage, currentAuthor);
+          // TODO: No deleteMyDocuments for IStorageAsync yet
+          //const { numDeleted } = deleteMyDocuments(storage, currentAuthor);
 
-          setNumberDeleted(numDeleted);
+          setNumberDeleted(/* numDeleted */ 0);
           setDeleted(true);
           setPrompt('');
         }}

--- a/src/components/EarthstarPeer.tsx
+++ b/src/components/EarthstarPeer.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { AuthorKeypair, IStorage } from 'earthstar';
+import { AuthorKeypair, IStorageAsync } from 'earthstar';
 import LiveSyncer from './_LiveSyncer';
 import {
   CurrentAuthorContext,
@@ -16,10 +16,9 @@ export default function EarthstarPeer({
   initCurrentAuthor = null,
   initCurrentWorkspace = null,
   initIsLive = true,
-
   children,
 }: {
-  initWorkspaces?: IStorage[];
+  initWorkspaces?: IStorageAsync[];
   initPubs?: Record<string, string[]>;
   initCurrentAuthor?: AuthorKeypair | null;
   initCurrentWorkspace?: string | null;
@@ -27,7 +26,7 @@ export default function EarthstarPeer({
   children: React.ReactNode;
 }) {
   const [storages, setStorages] = React.useState(
-    initWorkspaces.reduce<Record<string, IStorage>>((acc, storage) => {
+    initWorkspaces.reduce<Record<string, IStorageAsync>>((acc, storage) => {
       return { ...acc, [storage.workspace]: storage };
     }, {})
   );

--- a/src/components/EarthstarPeer.tsx
+++ b/src/components/EarthstarPeer.tsx
@@ -42,6 +42,12 @@ export default function EarthstarPeer({
   );
   const [isLive, setIsLive] = React.useState(initIsLive);
 
+  React.useEffect(() => {
+    return () => {
+      Object.values(storages).forEach(storage => storage.close());
+    };
+  }, [storages]);
+
   return (
     <StorageContext.Provider value={{ storages, setStorages }}>
       <PubsContext.Provider value={{ pubs, setPubs }}>

--- a/src/components/InvitationRedemptionForm.tsx
+++ b/src/components/InvitationRedemptionForm.tsx
@@ -120,7 +120,10 @@ export default function InvitationRedemptionForm({
               <dd data-re-dd>
                 {result.pubs.length > 0
                   ? result.pubs.map(pubUrl => (
-                      <div data-re-invitation-redemption-pub-list-item>
+                      <div
+                        key={pubUrl}
+                        data-re-invitation-redemption-pub-list-item
+                      >
                         <span data-re-pub-item key={pubUrl}>
                           <input
                             data-re-checkbox

--- a/src/components/LocalStorageSettingsWriter.tsx
+++ b/src/components/LocalStorageSettingsWriter.tsx
@@ -1,4 +1,3 @@
-import { StorageMemory } from 'earthstar';
 import * as React from 'react';
 import {
   useCurrentAuthor,
@@ -17,7 +16,7 @@ export default function LocalStorageSettingsWriter({
 }) {
   const lsAuthorKey = makeStorageKey(storageKey, 'current-author');
   const lsPubsKey = makeStorageKey(storageKey, 'pubs');
-  const lsStoragesKey = makeStorageKey(storageKey, 'storages');
+  const lsWorkspacesKey = makeStorageKey(storageKey, 'workspaces');
   const lsCurrentWorkspaceKey = makeStorageKey(storageKey, 'current-workspace');
   const lsIsLiveKey = makeStorageKey(storageKey, 'is-live');
 
@@ -29,15 +28,11 @@ export default function LocalStorageSettingsWriter({
 
   const onWrite = React.useCallback(() => {
     const storagesStringified = JSON.stringify(
-      Object.values(storages).reduce((acc, storage) => {
-        const { _docs } = storage as StorageMemory;
-
-        return { ...acc, [storage.workspace]: _docs };
-      }, {})
+      Object.keys(storages).map(key => key)
     );
 
-    localStorage.setItem(lsStoragesKey, storagesStringified);
-  }, [storages, lsStoragesKey]);
+    localStorage.setItem(lsWorkspacesKey, storagesStringified);
+  }, [storages, lsWorkspacesKey]);
 
   // Persist workspace docs on storage events
   useSubscribeToStorages({

--- a/src/components/_LiveSyncer.tsx
+++ b/src/components/_LiveSyncer.tsx
@@ -1,16 +1,16 @@
-//import * as React from 'react';
-//import { OnePubOneWorkspaceSyncer } from 'earthstar';
-//import { useIsLive, useStorages, useWorkspacePubs } from '../hooks';
+import * as React from 'react';
+import { OnePubOneWorkspaceSyncer } from 'earthstar';
+import { useIsLive, useStorages, useWorkspacePubs } from '../hooks';
 
-// TODO: There is no live syncing API for IStorageAsync yet
-
-export default function LiveSyncer({}: { workspaceAddress: string }) {
-  /*
+export default function LiveSyncer({
+  workspaceAddress,
+}: {
+  workspaceAddress: string;
+}) {
   const [isLive] = useIsLive();
   const [storages] = useStorages();
   const [pubs] = useWorkspacePubs(workspaceAddress);
 
-  
   React.useEffect(() => {
     const syncers = pubs.map(
       pubUrl => new OnePubOneWorkspaceSyncer(storages[workspaceAddress], pubUrl)
@@ -36,7 +36,6 @@ export default function LiveSyncer({}: { workspaceAddress: string }) {
       });
     };
   }, [pubs, isLive, workspaceAddress, storages]);
-  */
 
   return null;
 }

--- a/src/components/_LiveSyncer.tsx
+++ b/src/components/_LiveSyncer.tsx
@@ -1,16 +1,16 @@
-import * as React from 'react';
-import { OnePubOneWorkspaceSyncer } from 'earthstar';
-import { useIsLive, useStorages, useWorkspacePubs } from '../hooks';
+//import * as React from 'react';
+//import { OnePubOneWorkspaceSyncer } from 'earthstar';
+//import { useIsLive, useStorages, useWorkspacePubs } from '../hooks';
 
-export default function LiveSyncer({
-  workspaceAddress,
-}: {
-  workspaceAddress: string;
-}) {
+// TODO: There is no live syncing API for IStorageAsync yet
+
+export default function LiveSyncer({}: { workspaceAddress: string }) {
+  /*
   const [isLive] = useIsLive();
   const [storages] = useStorages();
   const [pubs] = useWorkspacePubs(workspaceAddress);
 
+  
   React.useEffect(() => {
     const syncers = pubs.map(
       pubUrl => new OnePubOneWorkspaceSyncer(storages[workspaceAddress], pubUrl)
@@ -36,6 +36,7 @@ export default function LiveSyncer({
       });
     };
   }, [pubs, isLive, workspaceAddress, storages]);
+  */
 
   return null;
 }

--- a/src/components/earthbar/MultiWorkspaceManagerPanel.tsx
+++ b/src/components/earthbar/MultiWorkspaceManagerPanel.tsx
@@ -8,6 +8,7 @@ import { WorkspaceOptions } from './WorkspaceOptions';
 import { EarthbarContext } from './contexts';
 import EarthbarTabPanel from './EarthbarTabPanel';
 import { WhatIsAWorkspace } from '../guidance/guidances';
+import DisplayNameForm from '../DisplayNameForm';
 
 type WorkspaceManagerState =
   | { screen: 'list' }
@@ -147,6 +148,11 @@ export default function MultiWorkspaceManagerPanel() {
               </button>
               {state.address}
             </nav>
+          </section>
+          <hr />
+          <section>
+            <h1>{'Customize your identity'}</h1>
+            <DisplayNameForm workspaceAddress={state.address} />
           </section>
           <hr />
           <WorkspaceOptions

--- a/src/components/earthbar/MultiWorkspaceTab.tsx
+++ b/src/components/earthbar/MultiWorkspaceTab.tsx
@@ -2,8 +2,18 @@ import * as React from 'react';
 import MultiWorkspaceManagerPanel from './MultiWorkspaceManagerPanel';
 import EarthbarTab from './EarthbarTab';
 import EarthbarTabLabel from './EarthbarTabLabel';
+import { useCurrentWorkspace } from '../../hooks';
 
 export default function MultiWorkspaceTab() {
+  const [currentWorkspace, setCurrentWorkspace] = useCurrentWorkspace();
+
+  // When in use, ensure that currentWorkspace is always null
+  React.useEffect(() => {
+    if (currentWorkspace) {
+      setCurrentWorkspace(null);
+    }
+  }, [currentWorkspace, setCurrentWorkspace]);
+
   return (
     <div data-re-earthbar-workspace-tab-zone>
       <EarthbarTab>

--- a/src/contexts.ts
+++ b/src/contexts.ts
@@ -1,9 +1,11 @@
-import { AuthorKeypair, IStorage } from 'earthstar';
+import { AuthorKeypair, IStorageAsync } from 'earthstar';
 import * as React from 'react';
 
 export const StorageContext = React.createContext<{
-  storages: Record<string, IStorage>; // workspace address --> IStorage instance
-  setStorages: React.Dispatch<React.SetStateAction<Record<string, IStorage>>>;
+  storages: Record<string, IStorageAsync>; // workspace address --> IStorage instance
+  setStorages: React.Dispatch<
+    React.SetStateAction<Record<string, IStorageAsync>>
+  >;
 }>({ storages: {}, setStorages: () => {} });
 
 export const PubsContext = React.createContext<{

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -63,6 +63,7 @@ export function useAddWorkspace() {
 
 export function useRemoveWorkspace(): (address: string) => Promise<void> {
   const [storages, setStorages] = useStorages();
+  const [pubs, setPubs] = usePubs();
   const [currentWorkspace, setCurrentWorkspace] = useCurrentWorkspace();
 
   return React.useCallback(
@@ -83,6 +84,10 @@ export function useRemoveWorkspace(): (address: string) => Promise<void> {
         const storage = storages[address];
 
         if (storage) {
+          const nextPubs = { ...pubs };
+          delete nextPubs[address];
+          setPubs(nextPubs);
+
           return storage
             .close({ delete: true })
             .then(resolve)
@@ -92,7 +97,14 @@ export function useRemoveWorkspace(): (address: string) => Promise<void> {
         return reject();
       });
     },
-    [setStorages, currentWorkspace, setCurrentWorkspace, storages]
+    [
+      setStorages,
+      currentWorkspace,
+      setCurrentWorkspace,
+      storages,
+      pubs,
+      setPubs,
+    ]
   );
 }
 

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -80,7 +80,7 @@ export function useRemoveWorkspace() {
       const storage = storages[address];
 
       if (storage) {
-        storage.close();
+        storage.close({ delete: true });
       }
     },
     [setStorages, currentWorkspace, setCurrentWorkspace, storages]
@@ -372,7 +372,7 @@ export function useStorages(): [
 export function useSubscribeToStorages(options: {
   workspaces?: string[];
   paths?: string[];
-  history?: Pick<Query, 'history'>['history'];
+  history?: Query['history'];
   onWrite: (event: WriteEvent) => void;
 }) {
   const [storages] = useStorages();

--- a/src/util.ts
+++ b/src/util.ts
@@ -78,14 +78,14 @@ export function useMemoQueryOpts({
   timestampGt,
   timestampLt,
 }: Query): Query {
-  return React.useMemo(
-    () => ({
+  return React.useMemo(() => {
+    const obj = {
       author,
       contentLength,
       contentLengthGt,
       contentLengthLt,
       continueAfter,
-      history,
+      ...(history ? { history } : {}),
       limit,
       limitBytes,
       path,
@@ -94,22 +94,23 @@ export function useMemoQueryOpts({
       timestamp,
       timestampGt,
       timestampLt,
-    }),
-    [
-      author,
-      contentLength,
-      contentLengthGt,
-      contentLengthLt,
-      continueAfter,
-      history,
-      limit,
-      limitBytes,
-      path,
-      pathEndsWith,
-      pathStartsWith,
-      timestamp,
-      timestampGt,
-      timestampLt,
-    ]
-  );
+    };
+
+    return obj;
+  }, [
+    author,
+    contentLength,
+    contentLengthGt,
+    contentLengthLt,
+    continueAfter,
+    history,
+    limit,
+    limitBytes,
+    path,
+    pathEndsWith,
+    pathStartsWith,
+    timestamp,
+    timestampGt,
+    timestampLt,
+  ]);
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { isErr, QueryOpts, ValidatorEs4 } from 'earthstar';
+import { isErr, Query, ValidatorEs4 } from 'earthstar';
 
 export function getAuthorShortName(address: string): string {
   const parsedAuthor = ValidatorEs4.parseAuthorAddress(address);
@@ -63,41 +63,53 @@ export function getLocalStorage<T>(key: string): T | null {
 }
 
 export function useMemoQueryOpts({
-  pathPrefix,
-  lowPath,
-  highPath,
-  contentIsEmpty,
-  includeHistory,
-  participatingAuthor,
-  path,
-  versionsByAuthor,
-  now,
+  author,
+  contentLength,
+  contentLengthGt,
+  contentLengthLt,
+  continueAfter,
+  history,
   limit,
-}: QueryOpts): QueryOpts {
+  limitBytes,
+  path,
+  pathEndsWith,
+  pathStartsWith,
+  timestamp,
+  timestampGt,
+  timestampLt,
+}: Query): Query {
   return React.useMemo(
     () => ({
-      pathPrefix,
-      lowPath,
-      highPath,
-      contentIsEmpty,
-      includeHistory,
-      participatingAuthor,
-      path,
-      versionsByAuthor,
-      now,
+      author,
+      contentLength,
+      contentLengthGt,
+      contentLengthLt,
+      continueAfter,
+      history,
       limit,
+      limitBytes,
+      path,
+      pathEndsWith,
+      pathStartsWith,
+      timestamp,
+      timestampGt,
+      timestampLt,
     }),
     [
-      pathPrefix,
-      lowPath,
-      highPath,
-      contentIsEmpty,
-      includeHistory,
-      participatingAuthor,
-      path,
-      versionsByAuthor,
-      now,
+      author,
+      contentLength,
+      contentLengthGt,
+      contentLengthLt,
+      continueAfter,
+      history,
       limit,
+      limitBytes,
+      path,
+      pathEndsWith,
+      pathStartsWith,
+      timestamp,
+      timestampGt,
+      timestampLt,
     ]
   );
 }

--- a/test/hooks.test.tsx
+++ b/test/hooks.test.tsx
@@ -43,10 +43,6 @@ const PUB_A = 'https://a.pub';
 const PUB_B = 'https://b.pub';
 const PUB_C = 'https://c.pub';
 
-const storages = [WORKSPACE_ADDR_A, WORKSPACE_ADDR_B, WORKSPACE_ADDR_C].map(
-  address => new StorageToAsync(new StorageMemory([ValidatorEs4], address), 0)
-);
-
 const pubs = {
   [WORKSPACE_ADDR_A]: [PUB_A],
   [WORKSPACE_ADDR_B]: [PUB_B],
@@ -54,6 +50,10 @@ const pubs = {
 };
 
 const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const storages = [WORKSPACE_ADDR_A, WORKSPACE_ADDR_B, WORKSPACE_ADDR_C].map(
+    address => new StorageToAsync(new StorageMemory([ValidatorEs4], address), 0)
+  );
+
   return (
     <EarthstarPeer
       initWorkspaces={storages}
@@ -373,9 +373,6 @@ test('useSubscribeToStorages', async () => {
     });
   });
 
-  console.log('DEBUG');
-  console.log(result.current.event);
-
   expect(result.current.event?.document.path).toEqual('/test/1');
   expect(result.current.event?.document.workspace).toEqual(WORKSPACE_ADDR_A);
   expect(result.current.event?.document.author).toEqual(keypair.address);
@@ -446,7 +443,7 @@ test('useSubscribeToStorages', async () => {
     });
   });
 
-  expect(workspaceResult.current.event?.document.path).toEqual('/test/b');
+  expect(pathResult.current.event?.document.path).toEqual('/test/b');
 
   // Can listen for all history
   const { result: historyResult } = renderHook(
@@ -597,7 +594,6 @@ test('useLocalStorageSettings', () => {
   );
 
   expect(result.current.initWorkspaces).toHaveLength(3);
-  expect(result.current.initWorkspaces[0]._docs._docs).toBeUndefined();
   expect(result.current.initPubs).toEqual({
     '+testa.a123': ['https://a.pub'],
     '+testb.b234': ['https://b.pub'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3469,10 +3469,10 @@ duplexer2@~0.1.4:
   dependencies:
     readable-stream "^2.0.2"
 
-earthstar@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/earthstar/-/earthstar-6.1.0.tgz#a6ee1369e4540d4f2540f4d1a794cf7900926815"
-  integrity sha512-dNJnBOhIDou1ttEgjDgtlt91R8QVhIW/Ul+gHu+eoldZp4M7Uin9MObE7O5f3LOipXEHQQuURaum3sCDulJpFw==
+earthstar@^6.3.1:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/earthstar/-/earthstar-6.3.1.tgz#8853792904fbb90efeb5efd7c7e80ab8dd331442"
+  integrity sha512-+kDIE+Fzk+R98zwKrUo7AiEWYtylupn4PRnFrsRrLA+vtljBmuoaSjo4jZYvTiCYb0pAbv6T0eOiGnWw0atDJQ==
   dependencies:
     "@types/better-sqlite3" "^5.4.1"
     "@types/isomorphic-fetch" "0.0.35"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1449,6 +1449,13 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/better-sqlite3@^5.4.1":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@types/better-sqlite3/-/better-sqlite3-5.4.1.tgz#d45600bc19f8f41397263d037ca9b0d05df85e58"
+  integrity sha512-8hje3Rhsg/9veTkALfCwiWn7VMrP1QDwHhBSgerttYPABEvrHsMQnU9dlqoM6QX3x4uw3Y06dDVz8uDQo1J4Ng==
+  dependencies:
+    "@types/integer" "*"
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -1470,6 +1477,11 @@
   integrity sha512-AiHRaEB50LQg0pZmm659vNBb9f4SJ0qrAnteuzhSeAUcJKxoYgEnprg/83kppCnc2zvtCKbdZry1a5pVY3lOTQ==
   dependencies:
     "@types/node" "*"
+
+"@types/integer@*":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/integer/-/integer-1.0.1.tgz#025d87e30d97f539fcc6087372af7d3672ffbbe6"
+  integrity sha512-DmZDpSVnsuBrOhtHwE1oKmUJ3qVjHhhNQ7WnZy9/RhH3A24Ar+9o4SoaCWcTzQhalpRDIAMsfdoZLWNJtdBR7A==
 
 "@types/isomorphic-fetch@0.0.35":
   version "0.0.35"
@@ -1528,6 +1540,13 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
+"@types/multibase@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@types/multibase/-/multibase-0.6.0.tgz#a729395114a875918ac139ab3107866975a9329d"
+  integrity sha512-PhQiA4pCcIG5yibX/G7K7mk/CXw0HTY98R+efcbbfce9WOyAGbIVqY3zv5kMm+vMAunY29aeOtQ96ePjeX417w==
+  dependencies:
+    "@types/node" "*"
 
 "@types/node@*":
   version "14.10.1"
@@ -2230,14 +2249,14 @@ bencode@^2.0.1:
   dependencies:
     safe-buffer "^5.1.1"
 
-better-sqlite3@^7.0.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-7.1.1.tgz#107457a8b770cfb16be646e347c17b42bc204dd3"
-  integrity sha512-AkvGGyhAVZhRBOul2WT+5CB2EuveM3ZkebEKe1wxMqDZUy1XB/1RBgM66t0ybHC4DIni8+pr7NaLqEX87NUTwg==
+better-sqlite3@^7.1.1:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-7.1.2.tgz#95565757a834093f1ecae0d4457f60820ed5dd2a"
+  integrity sha512-8FWYnJ6Bx94MBX03J5Ka7sTRlvXXMEm4FW2Op7nM8ErQZeyALYLmSlbMBnfr4cMpS0tj0aYZv0a+26G2YJuIjg==
   dependencies:
     bindings "^1.5.0"
     prebuild-install "^5.3.3"
-    tar "4.4.10"
+    tar "^6.0.5"
 
 binary-extensions@^1.0.0:
   version "1.13.1"
@@ -2604,12 +2623,11 @@ chloride-test@^1.1.0:
   dependencies:
     json-buffer "^2.0.11"
 
-chloride@^2.2.14:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/chloride/-/chloride-2.3.0.tgz#6d10ce031e472d6261d840150a22c55fe78c730c"
-  integrity sha512-9jcavUx9ZNW9hxkG24rS9QddHpOqLAZqcb5SRbABRa8NKcplBKKcZfNM5LMa3DQ/VfXBQzcLDjgSo3uHA1ibZg==
+chloride@^2.3.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chloride/-/chloride-2.4.1.tgz#295a30f2ffbe316b6c4c82550dcbc262703f082d"
+  integrity sha512-ZiID87W2o2llvuF4C7Fvt9GJisazSdMsSkjAq4WaMed9zn77nlkcy08ZfrPtOGAXyaxTDj0VjnuyD97EdJLz3g==
   dependencies:
-    is-electron "^2.2.0"
     sodium-browserify "^1.2.7"
     sodium-browserify-tweetnacl "^0.2.5"
     sodium-chloride "^1.1.2"
@@ -2639,6 +2657,11 @@ chownr@^1.1.1:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
+
+chownr@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
+  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
 ci-info@^2.0.0:
   version "2.0.0"
@@ -2834,6 +2857,13 @@ concat-stream@~1.6.0:
     inherits "^2.0.3"
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
+
+concurrency-friends@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/concurrency-friends/-/concurrency-friends-0.2.0.tgz#572142df624c7aa03e9994160c8cc5ebdd3e1416"
+  integrity sha512-/JqCGigxAKGHlkWQ4OXe+C+hKU4q7Wr0fa5aPM3eh9FNiv34Wgsl3LsmuOswK3hdoMt8Epv9B1C24biWFrIRlQ==
+  dependencies:
+    stable "^0.1.8"
 
 confusing-browser-globals@^1.0.9:
   version "1.0.9"
@@ -3439,19 +3469,24 @@ duplexer2@~0.1.4:
   dependencies:
     readable-stream "^2.0.2"
 
-earthstar@^5.7.6:
-  version "5.7.6"
-  resolved "https://registry.yarnpkg.com/earthstar/-/earthstar-5.7.6.tgz#c837c2c40b2d093a9dea76cc84bae746513b9b13"
-  integrity sha512-JwK4c7ErCZII/epUzgeA/5Ul6G/tifxe2XFhi3kLjAfqM/lavmDsnq8wWb5vh40Pa84OkwzfYFa6+AceHwyjgA==
+earthstar@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/earthstar/-/earthstar-6.1.0.tgz#a6ee1369e4540d4f2540f4d1a794cf7900926815"
+  integrity sha512-dNJnBOhIDou1ttEgjDgtlt91R8QVhIW/Ul+gHu+eoldZp4M7Uin9MObE7O5f3LOipXEHQQuURaum3sCDulJpFw==
   dependencies:
+    "@types/better-sqlite3" "^5.4.1"
     "@types/isomorphic-fetch" "0.0.35"
+    "@types/multibase" "^0.6.0"
     bencode "^2.0.1"
-    better-sqlite3 "^7.0.1"
-    chloride "^2.2.14"
+    better-sqlite3 "^7.1.1"
+    chalk "^4.1.0"
+    chloride "^2.3.0"
+    concurrency-friends "^0.2.0"
     fast-equals "^2.0.0"
     isomorphic-fetch "^2.2.1"
-    multibase "^0.7.0"
-    tslib "^2.0.0"
+    lodash.debounce "^4.0.8"
+    multibase "^2.0.0"
+    tslib "^2.0.3"
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"
@@ -4266,12 +4301,12 @@ fs-extra@^9.0.0:
     jsonfile "^6.0.1"
     universalify "^1.0.0"
 
-fs-minipass@^1.2.5:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
-  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
+fs-minipass@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
+  integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
   dependencies:
-    minipass "^2.6.0"
+    minipass "^3.0.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -4945,11 +4980,6 @@ is-docker@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.1.1.tgz#4125a88e44e450d384e09047ede71adc2d144156"
   integrity sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==
-
-is-electron@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/is-electron/-/is-electron-2.2.0.tgz#8943084f09e8b731b3a7a0298a7b5d56f6b7eef0"
-  integrity sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q==
 
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
@@ -6183,20 +6213,20 @@ minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
-minipass@^2.3.5, minipass@^2.6.0, minipass@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
-  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
+minipass@^3.0.0:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.3.tgz#7d42ff1f39635482e15f9cdb53184deebd5815fd"
+  integrity sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==
   dependencies:
-    safe-buffer "^5.1.2"
-    yallist "^3.0.0"
+    yallist "^4.0.0"
 
-minizlib@^1.2.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
-  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
+minizlib@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
+  integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
   dependencies:
-    minipass "^2.9.0"
+    minipass "^3.0.0"
+    yallist "^4.0.0"
 
 mixin-deep@^1.2.0:
   version "1.3.2"
@@ -6211,14 +6241,14 @@ mkdirp-classic@^0.5.2:
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
   integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
-mkdirp@0.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
+mkdirp@0.x, mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
 
-mkdirp@1.x:
+mkdirp@1.x, mkdirp@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -6243,13 +6273,14 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-multibase@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/multibase/-/multibase-0.7.0.tgz#1adfc1c50abe05eefeb5091ac0c2728d6b84581b"
-  integrity sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==
+multibase@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/multibase/-/multibase-2.0.0.tgz#e20a2a14813fa435dc69c702909209ac0741919e"
+  integrity sha512-xIrqUVsinSlFjqj+OtEgCJ6MRl5hXjHMBPWsUt1ZGSRMx8rzm+7hCLE4wDeSA3COomlUC9zHCoUlvWjvAMtfDg==
   dependencies:
     base-x "^3.0.8"
     buffer "^5.5.0"
+    web-encoding "^1.0.2"
 
 mute-stream@0.0.8:
   version "0.0.8"
@@ -8753,18 +8784,17 @@ tar-stream@^2.0.0:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@4.4.10:
-  version "4.4.10"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.10.tgz#946b2810b9a5e0b26140cf78bea6b0b0d689eba1"
-  integrity sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==
+tar@^6.0.5:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.0.tgz#d1724e9bcc04b977b18d5c573b333a2207229a83"
+  integrity sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==
   dependencies:
-    chownr "^1.1.1"
-    fs-minipass "^1.2.5"
-    minipass "^2.3.5"
-    minizlib "^1.2.1"
-    mkdirp "^0.5.0"
-    safe-buffer "^5.1.2"
-    yallist "^3.0.3"
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^3.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
 
 terminal-link@^2.0.0:
   version "2.1.1"
@@ -9061,6 +9091,11 @@ tslib@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
   integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
+
+tslib@^2.0.3:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
+  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
 tsutils@^3.17.1:
   version "3.17.1"
@@ -9392,6 +9427,11 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
+web-encoding@^1.0.2:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/web-encoding/-/web-encoding-1.0.6.tgz#ec631356ee523b4474ecbcae680440bd1e79416a"
+  integrity sha512-26wEnRPEFAc5d5lmH1Q/DuvWEYsRF1D2alX2jlKpdmqv7cj+BbANL7Xlcl9r4s72Eg9kItZa9RWVbBMC9dMv4w==
+
 webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
@@ -9537,10 +9577,10 @@ y18n@^4.0.0:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
 
-yallist@^3.0.0, yallist@^3.0.3:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
-  integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yaml@^1.10.0, yaml@^1.7.2:
   version "1.10.0"


### PR DESCRIPTION
Here's the big update to Earthstar v6.3.1. This'll be a breaking version change, to v2.0.0! Upgrading to v6 wasn't too much work, but the big change here is for EarthstarPeer's internal workspace storages are now asynchronous. This means we can easily switch over to IndexedDB when that comes along.

In future when React has Suspense, a few internals and APIs will be simplified. Until then, this API will have to do.

# Big Earthstar update stuff

- Updates to earthstar v6.3.1
- Updates the EarthstarPeer's internal storage state to use `IStorageAsync`
- Forgoes own LocalStorage for Earthstar's `StorageLocalStorage`

# Other fixes I snuck into here

- Makes it so that when MultiWorkspaceTab is in use that the currentWorkspace is always `null`.
- When you remove a workspace, its pubs are now forgotten too
- Added a display name form to multiworkspace settings
