### PR TITLE
Don’t sync on visibilitychange, only close removed storages

### DIFF
--- a/examples/earthbar/index.tsx
+++ b/examples/earthbar/index.tsx
@@ -6,6 +6,7 @@ import {
   generateAuthorKeypair,
   AuthorKeypair,
   StorageToAsync,
+  setLogLevels,
 } from 'earthstar';
 import {
   EarthstarPeer,
@@ -24,6 +25,14 @@ const EXAMPLE_WORKSPACE_ADDR2 = '+gardening.a123';
 const EXAMPLE_WORKSPACE_ADDR3 = '+sailing.a123';
 
 const EXAMPLE_USER = generateAuthorKeypair('test') as AuthorKeypair;
+
+// 0: error, 1: warn, 2: log, 3: debug
+setLogLevels({
+  sync: 2,
+  syncer2: 2,
+  storage: 2,
+  _other: 2,
+});
 
 const pubs = {
   [EXAMPLE_WORKSPACE_ADDR1]: [

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "earthbar-example": "parcel examples/earthbar/index.html"
   },
   "peerDependencies": {
-    "earthstar": "^6.3.1",
+    "earthstar": "^6.3.4",
     "react": "~16.13.1"
   },
   "husky": {
@@ -49,7 +49,7 @@
     "@types/jest": "^26.0.14",
     "@types/react-dom": "^16.9.8",
     "babel-jest": "^26.5.2",
-    "earthstar": "^6.3.1",
+    "earthstar": "^6.3.4",
     "eslint-plugin-react-hooks": "^4.1.2",
     "husky": "^4.3.0",
     "jest-localstorage-mock": "^2.4.6",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "earthbar-example": "parcel examples/earthbar/index.html"
   },
   "peerDependencies": {
-    "earthstar": "^6.3.4",
+    "earthstar": "^6.3.5",
     "react": "~16.13.1"
   },
   "husky": {
@@ -49,7 +49,7 @@
     "@types/jest": "^26.0.14",
     "@types/react-dom": "^16.9.8",
     "babel-jest": "^26.5.2",
-    "earthstar": "^6.3.4",
+    "earthstar": "^6.3.5",
     "eslint-plugin-react-hooks": "^4.1.2",
     "husky": "^4.3.0",
     "jest-localstorage-mock": "^2.4.6",

--- a/src/components/DeleteMyDataForm.tsx
+++ b/src/components/DeleteMyDataForm.tsx
@@ -40,7 +40,6 @@ export default function DeleteMyDataForm(props: { workspaceAddress: string }) {
         onChange={e => setPrompt(e.target.value)}
       />
       <button
-        {...props}
         data-re-button
         data-re-delete-my-data-button
         onClick={async () => {

--- a/src/components/EarthstarPeer.tsx
+++ b/src/components/EarthstarPeer.tsx
@@ -9,6 +9,7 @@ import {
   StorageContext,
 } from '../contexts';
 import FocusSyncer from './_FocusSyncer';
+import { usePrevious } from '@reach/utils';
 
 export default function EarthstarPeer({
   initWorkspaces = [],
@@ -42,11 +43,23 @@ export default function EarthstarPeer({
   );
   const [isLive, setIsLive] = React.useState(initIsLive);
 
+  const prevStorages = usePrevious(storages);
+
+  // Close any workspace storages which have been removed from storages
   React.useEffect(() => {
-    return () => {
-      Object.values(storages).forEach(storage => storage.close());
-    };
-  }, [storages]);
+    const storagesSet = new Set(Object.values(storages));
+
+    const difference = Array.from(Object.values(prevStorages || [])).filter(
+      storage => !storagesSet.has(storage)
+    );
+
+    difference.forEach(
+      storage => {
+        storage.close({ delete: true });
+      },
+      [storages, prevStorages]
+    );
+  }, [storages, prevStorages]);
 
   return (
     <StorageContext.Provider value={{ storages, setStorages }}>

--- a/src/components/_FocusSyncer.tsx
+++ b/src/components/_FocusSyncer.tsx
@@ -12,21 +12,19 @@ export default function FocusSyncer() {
     }
 
     Object.keys(storages).forEach(address => {
-      console.log(`syncing ${address} on focus...`);
-      sync(address);
+      sync(address).catch(err => {
+        console.error(err);
+      });
     });
   }, [sync, storages, isLive]);
 
   React.useEffect(() => {
-    window.addEventListener('visibilitychange', onFocus, false);
     window.addEventListener('focus', onFocus, false);
 
     return () => {
-      // Be sure to unsubscribe if a new handler is set
-      window.removeEventListener('visibilitychange', onFocus);
       window.removeEventListener('focus', onFocus);
     };
-  });
+  }, [onFocus]);
 
   return null;
 }

--- a/src/components/_FocusSyncer.tsx
+++ b/src/components/_FocusSyncer.tsx
@@ -12,9 +12,7 @@ export default function FocusSyncer() {
     }
 
     Object.keys(storages).forEach(address => {
-      sync(address).catch(err => {
-        console.error(err);
-      });
+      sync(address);
     });
   }, [sync, storages, isLive]);
 

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -61,41 +61,32 @@ export function useAddWorkspace() {
   );
 }
 
-export function useRemoveWorkspace(): (address: string) => Promise<void> {
+export function useRemoveWorkspace(): (address: string) => void {
   const [storages, setStorages] = useStorages();
   const [pubs, setPubs] = usePubs();
   const [currentWorkspace, setCurrentWorkspace] = useCurrentWorkspace();
 
   return React.useCallback(
     (address: string) => {
-      return new Promise<void>((resolve, reject) => {
-        if (currentWorkspace === address) {
-          setCurrentWorkspace(null);
-        }
+      if (currentWorkspace === address) {
+        setCurrentWorkspace(null);
+      }
 
-        setStorages(prev => {
-          const prevCopy = { ...prev };
+      setStorages(prev => {
+        const prevCopy = { ...prev };
 
-          delete prevCopy[address];
+        delete prevCopy[address];
 
-          return prevCopy;
-        });
-
-        const storage = storages[address];
-
-        if (storage) {
-          const nextPubs = { ...pubs };
-          delete nextPubs[address];
-          setPubs(nextPubs);
-
-          return storage
-            .close({ delete: true })
-            .then(resolve)
-            .catch(reject);
-        }
-
-        return reject();
+        return prevCopy;
       });
+
+      const storage = storages[address];
+
+      if (storage) {
+        const nextPubs = { ...pubs };
+        delete nextPubs[address];
+        setPubs(nextPubs);
+      }
     },
     [
       setStorages,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3469,10 +3469,10 @@ duplexer2@~0.1.4:
   dependencies:
     readable-stream "^2.0.2"
 
-earthstar@^6.3.1:
-  version "6.3.1"
-  resolved "https://registry.yarnpkg.com/earthstar/-/earthstar-6.3.1.tgz#8853792904fbb90efeb5efd7c7e80ab8dd331442"
-  integrity sha512-+kDIE+Fzk+R98zwKrUo7AiEWYtylupn4PRnFrsRrLA+vtljBmuoaSjo4jZYvTiCYb0pAbv6T0eOiGnWw0atDJQ==
+earthstar@^6.3.4:
+  version "6.3.4"
+  resolved "https://registry.yarnpkg.com/earthstar/-/earthstar-6.3.4.tgz#b47fce29f023e62cd0909ef1a8022f2cbf034b2f"
+  integrity sha512-xX/h3UxYoROkwTHuQ/TwQysPUHLdZRjM8qA/q5R2eOmGKRpVYi6Hf7bUAAljSyP/5/8fkdUxpw1dO1rlRrzZHA==
   dependencies:
     "@types/better-sqlite3" "^5.4.1"
     "@types/isomorphic-fetch" "0.0.35"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3469,10 +3469,10 @@ duplexer2@~0.1.4:
   dependencies:
     readable-stream "^2.0.2"
 
-earthstar@^6.3.4:
-  version "6.3.4"
-  resolved "https://registry.yarnpkg.com/earthstar/-/earthstar-6.3.4.tgz#b47fce29f023e62cd0909ef1a8022f2cbf034b2f"
-  integrity sha512-xX/h3UxYoROkwTHuQ/TwQysPUHLdZRjM8qA/q5R2eOmGKRpVYi6Hf7bUAAljSyP/5/8fkdUxpw1dO1rlRrzZHA==
+earthstar@^6.3.5:
+  version "6.3.5"
+  resolved "https://registry.yarnpkg.com/earthstar/-/earthstar-6.3.5.tgz#49e08cc31928be86820e8d84995c483f22551f4e"
+  integrity sha512-TrdPeV+4akMUqbgAozYlPBJinv2XOX6udWqsoAx5n6/YRmDb/lQxqpOtHUsXsnOsi29ERbe/CPQ36Anh4vOkmQ==
   dependencies:
     "@types/better-sqlite3" "^5.4.1"
     "@types/isomorphic-fetch" "0.0.35"


### PR DESCRIPTION
Updated with fixes for #62 and #64.

- Updates to earthstar@6.3.4
- Updated `EarthstarPeer` to close storages which were _removed_. I've done this here instead of in `useRemoveWorkspace` because I'd like this to happen any time a storage is removed using `useStorages` without the user needing to remember to.
- Remove syncing happening on 'visibilitychange', which also would happen when the page was _hidden_.
  - It would also overlap with the `focus` event, causing two syncs when returning to a tab.